### PR TITLE
[Feat] 편의점 정보 게시글에 '올바른정보예요/잘못된정보예요' 설정 API 구현 

### DIFF
--- a/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
+++ b/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import com.kkinikong.be.convenience.dto.request.ConveniencePostInfoRequest;
 import com.kkinikong.be.convenience.dto.request.ConvenienceRequest;
 import com.kkinikong.be.convenience.dto.response.ConveniencePostResponse;
 import com.kkinikong.be.convenience.service.ConvenienceService;
@@ -68,7 +69,7 @@ public class ConvenienceController {
   @PostMapping("/post/{postId}/info")
   public ResponseEntity<ApiResponse<Object>> addConveniencePostInfo(
       @PathVariable("postId") Long postId,
-      @RequestBody @Valid ConveniencePostInfoRequet request,
+      @RequestBody @Valid ConveniencePostInfoRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     convenienceService.addConveniencePostInfo(postId, request.getIsCorrect(), userDetails.getId());
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);

--- a/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
+++ b/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.kkinikong.be.convenience.dto.request.ConveniencePostInfoRequest;
 import com.kkinikong.be.convenience.dto.request.ConvenienceRequest;
+import com.kkinikong.be.convenience.dto.response.ConveniencePostInfoResponse;
 import com.kkinikong.be.convenience.dto.response.ConveniencePostResponse;
 import com.kkinikong.be.convenience.service.ConvenienceService;
 import com.kkinikong.be.global.response.ApiResponse;
@@ -78,7 +79,8 @@ public class ConvenienceController {
       @PathVariable("postId") Long postId,
       @RequestBody @Valid ConveniencePostInfoRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-    convenienceService.addConveniencePostInfo(postId, request.isCorrect(), userDetails.getId());
-    return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    ConveniencePostInfoResponse response =
+        convenienceService.addConveniencePostInfo(postId, request.isCorrect(), userDetails.getId());
+    return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(response));
   }
 }

--- a/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
+++ b/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
@@ -63,4 +63,14 @@ public class ConvenienceController {
     convenienceService.deleteConveniencePost(postId, userDetails.getId());
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
   }
+
+  @Operation(summary = "편의점 정보 게시글에 '올바른/잘못된 정보' 표시")
+  @PostMapping("/post/{postId}/info")
+  public ResponseEntity<ApiResponse<Object>> addConveniencePostInfo(
+      @PathVariable("postId") Long postId,
+      @RequestBody @Valid ConveniencePostInfoRequet request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    convenienceService.addConveniencePostInfo(postId, request.getIsCorrect(), userDetails.getId());
+    return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+  }
 }

--- a/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
+++ b/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
@@ -65,7 +65,14 @@ public class ConvenienceController {
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
   }
 
-  @Operation(summary = "편의점 정보 게시글에 '올바른/잘못된 정보' 표시")
+  @Operation(
+      summary = "편의점 정보 게시글에 '올바른/잘못된 정보' 표시",
+      description =
+          """
+          - `true` : 올바른 정보예요
+          - `false` : 잘못된 정보예요
+          - 사용자는 게시글당 한 번만 평가할 수 있으며, 기존 평가가 있는 경우 수정됩니다.
+          """)
   @PostMapping("/post/{postId}/info")
   public ResponseEntity<ApiResponse<Object>> addConveniencePostInfo(
       @PathVariable("postId") Long postId,

--- a/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
+++ b/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
@@ -71,7 +71,7 @@ public class ConvenienceController {
       @PathVariable("postId") Long postId,
       @RequestBody @Valid ConveniencePostInfoRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-    convenienceService.addConveniencePostInfo(postId, request.getIsCorrect(), userDetails.getId());
+    convenienceService.addConveniencePostInfo(postId, request.isCorrect(), userDetails.getId());
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
   }
 }

--- a/src/main/java/com/kkinikong/be/convenience/domain/ConvenienceHelpful.java
+++ b/src/main/java/com/kkinikong/be/convenience/domain/ConvenienceHelpful.java
@@ -1,6 +1,7 @@
 package com.kkinikong.be.convenience.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +28,15 @@ public class ConvenienceHelpful extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
+
+  @Builder
+  public ConvenienceHelpful(User user, ConveniencePost conveniencePost, Boolean isCorrect) {
+    this.user = user;
+    this.conveniencePost = conveniencePost;
+    this.isCorrect = isCorrect;
+  }
+
+  public void updateIsCorrect(Boolean isCorrect) {
+    this.isCorrect = isCorrect;
+  }
 }

--- a/src/main/java/com/kkinikong/be/convenience/domain/ConveniencePost.java
+++ b/src/main/java/com/kkinikong/be/convenience/domain/ConveniencePost.java
@@ -69,4 +69,14 @@ public class ConveniencePost extends BaseEntity {
     this.isAvailable = isAvailable;
     this.user = user;
   }
+
+  public void increaseCount(boolean isCorrect) {
+    if (isCorrect) this.correctCount++;
+    else this.incorrectCount++;
+  }
+
+  public void decreaseCount(boolean isCorrect) {
+    if (isCorrect && correctCount > 0) this.correctCount--;
+    else if (!isCorrect && incorrectCount > 0) this.incorrectCount--;
+  }
 }

--- a/src/main/java/com/kkinikong/be/convenience/dto/request/ConveniencePostInfoRequest.java
+++ b/src/main/java/com/kkinikong/be/convenience/dto/request/ConveniencePostInfoRequest.java
@@ -1,0 +1,3 @@
+package com.kkinikong.be.convenience.dto.request;
+
+public record ConveniencePostInfoRequest(Boolean isCorrect) {}

--- a/src/main/java/com/kkinikong/be/convenience/dto/response/ConveniencePostInfoResponse.java
+++ b/src/main/java/com/kkinikong/be/convenience/dto/response/ConveniencePostInfoResponse.java
@@ -1,0 +1,4 @@
+package com.kkinikong.be.convenience.dto.response;
+
+public record ConveniencePostInfoResponse(
+    long correctCount, long incorrectCount, Boolean userSelection) {}

--- a/src/main/java/com/kkinikong/be/convenience/exception/errorcode/ConvenienceErrorCode.java
+++ b/src/main/java/com/kkinikong/be/convenience/exception/errorcode/ConvenienceErrorCode.java
@@ -14,6 +14,7 @@ public enum ConvenienceErrorCode implements ErrorCode {
   PARSE_CHOICES_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OpenAI API 응답 파싱에 실패했습니다."),
   CONVENIENCE_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "편의점 정보 게시글을 찾을 수 없습니다."),
   CONVENIENCE_POST_NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "편의점 정보 게시글의 작성자가 아닙니다."),
+  NOT_ALLOWED_TO_SELECT_OWN_POST(HttpStatus.FORBIDDEN, "본인이 작성한 편의점 정보 게시글에서는 선택할 수 없습니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceHelpfulRepository.java
+++ b/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceHelpfulRepository.java
@@ -1,9 +1,16 @@
 package com.kkinikong.be.convenience.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.kkinikong.be.convenience.domain.ConvenienceHelpful;
+import com.kkinikong.be.convenience.domain.ConveniencePost;
+import com.kkinikong.be.user.domain.User;
 
 @Repository
-public interface ConvenienceHelpfulRepository extends JpaRepository<ConvenienceHelpful, Long> {}
+public interface ConvenienceHelpfulRepository extends JpaRepository<ConvenienceHelpful, Long> {
+  Optional<ConvenienceHelpful> findByConveniencePostAndUser(
+      ConveniencePost conveniencePost, User user);
+}

--- a/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceHelpfulRepository.java
+++ b/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceHelpfulRepository.java
@@ -1,0 +1,9 @@
+package com.kkinikong.be.convenience.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.kkinikong.be.convenience.domain.ConvenienceHelpful;
+
+@Repository
+public interface ConvenienceHelpfulRepository extends JpaRepository<ConvenienceHelpful, Long> {}

--- a/src/main/java/com/kkinikong/be/convenience/service/ConvenienceService.java
+++ b/src/main/java/com/kkinikong/be/convenience/service/ConvenienceService.java
@@ -70,9 +70,16 @@ public class ConvenienceService {
     ConveniencePost conveniencePost = getConveniencePostOrThrow(postId);
     User user = getUserOrThrow(userId);
 
+    // 본인이 작성한 게시글에 대해서는 선택 불가능
+    if (conveniencePost.getUser().getId().equals(user.getId())) {
+      throw new ConvenienceException(ConvenienceErrorCode.NOT_ALLOWED_TO_SELECT_OWN_POST);
+    }
+
+    // 이전에 해당 게시글에 대해 사용자의 선택이 있는지 확인
     Optional<ConvenienceHelpful> optionalHelpful =
         helpfulRepository.findByConveniencePostAndUser(conveniencePost, user);
 
+    // 기존 선택과 동일한 값이면 아무 변화 없이 현재 상태 반환
     if (optionalHelpful.isPresent()) {
       ConvenienceHelpful existing = optionalHelpful.get();
       if (existing.getIsCorrect().equals(isCorrect)) {
@@ -80,9 +87,11 @@ public class ConvenienceService {
             conveniencePost.getCorrectCount(), conveniencePost.getIncorrectCount(), isCorrect);
       }
 
+      // 이전 선택을 취소하고 새로 선택
       conveniencePost.decreaseCount(existing.getIsCorrect());
       existing.updateIsCorrect(isCorrect);
     } else {
+      // 첫 선택일 경우
       ConvenienceHelpful newHelpful =
           ConvenienceHelpful.builder()
               .user(user)

--- a/src/main/java/com/kkinikong/be/convenience/service/ConvenienceService.java
+++ b/src/main/java/com/kkinikong/be/convenience/service/ConvenienceService.java
@@ -1,17 +1,21 @@
 package com.kkinikong.be.convenience.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.kkinikong.be.convenience.domain.ConvenienceHelpful;
 import com.kkinikong.be.convenience.domain.ConveniencePost;
 import com.kkinikong.be.convenience.dto.request.ConvenienceRequest;
 import com.kkinikong.be.convenience.dto.response.ConveniencePostResponse;
 import com.kkinikong.be.convenience.dto.response.ConvenienceRecommendationResponse;
 import com.kkinikong.be.convenience.exception.ConvenienceException;
 import com.kkinikong.be.convenience.exception.errorcode.ConvenienceErrorCode;
+import com.kkinikong.be.convenience.repository.ConvenienceHelpfulRepository;
 import com.kkinikong.be.convenience.repository.ConvenienceRepository;
 import com.kkinikong.be.convenience.util.OpenAIApiClient;
 import com.kkinikong.be.convenience.util.dto.OpenAIRequest;
@@ -28,7 +32,7 @@ public class ConvenienceService {
 
   private final ConvenienceRepository convenienceRepository;
   private final UserRepository userRepository;
-
+  private final ConvenienceHelpfulRepository helpfulRepository;
   private final OpenAIApiClient openAIApiClient;
 
   public ConvenienceRecommendationResponse getProductNameRecommendation(String productName) {
@@ -57,6 +61,32 @@ public class ConvenienceService {
     ConveniencePost conveniencePost = getConveniencePostOrThrow(postId);
     validateConveniencePostOwner(conveniencePost, userId);
     convenienceRepository.delete(conveniencePost);
+  }
+
+  @Transactional
+  public void addConveniencePostInfo(Long postId, Boolean isCorrect, Long userId) {
+    ConveniencePost conveniencePost = getConveniencePostOrThrow(postId);
+    User user = getUserOrThrow(userId);
+
+    Optional<ConvenienceHelpful> optionalHelpful =
+        helpfulRepository.findByConveniencePostAndUser(conveniencePost, user);
+
+    if (optionalHelpful.isPresent()) {
+      ConvenienceHelpful existing = optionalHelpful.get();
+      if (existing.getIsCorrect().equals(isCorrect)) return;
+
+      conveniencePost.decreaseCount(existing.getIsCorrect());
+      existing.updateIsCorrect(isCorrect);
+    } else {
+      ConvenienceHelpful newHelpful =
+          ConvenienceHelpful.builder()
+              .user(user)
+              .conveniencePost(conveniencePost)
+              .isCorrect(isCorrect)
+              .build();
+      helpfulRepository.save(newHelpful);
+    }
+    conveniencePost.increaseCount(isCorrect);
   }
 
   private User getUserOrThrow(Long userId) {

--- a/src/main/java/com/kkinikong/be/convenience/service/ConvenienceService.java
+++ b/src/main/java/com/kkinikong/be/convenience/service/ConvenienceService.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import com.kkinikong.be.convenience.domain.ConvenienceHelpful;
 import com.kkinikong.be.convenience.domain.ConveniencePost;
 import com.kkinikong.be.convenience.dto.request.ConvenienceRequest;
+import com.kkinikong.be.convenience.dto.response.ConveniencePostInfoResponse;
 import com.kkinikong.be.convenience.dto.response.ConveniencePostResponse;
 import com.kkinikong.be.convenience.dto.response.ConvenienceRecommendationResponse;
 import com.kkinikong.be.convenience.exception.ConvenienceException;
@@ -64,7 +65,8 @@ public class ConvenienceService {
   }
 
   @Transactional
-  public void addConveniencePostInfo(Long postId, Boolean isCorrect, Long userId) {
+  public ConveniencePostInfoResponse addConveniencePostInfo(
+      Long postId, Boolean isCorrect, Long userId) {
     ConveniencePost conveniencePost = getConveniencePostOrThrow(postId);
     User user = getUserOrThrow(userId);
 
@@ -73,7 +75,10 @@ public class ConvenienceService {
 
     if (optionalHelpful.isPresent()) {
       ConvenienceHelpful existing = optionalHelpful.get();
-      if (existing.getIsCorrect().equals(isCorrect)) return;
+      if (existing.getIsCorrect().equals(isCorrect)) {
+        return new ConveniencePostInfoResponse(
+            conveniencePost.getCorrectCount(), conveniencePost.getIncorrectCount(), isCorrect);
+      }
 
       conveniencePost.decreaseCount(existing.getIsCorrect());
       existing.updateIsCorrect(isCorrect);
@@ -86,7 +91,11 @@ public class ConvenienceService {
               .build();
       helpfulRepository.save(newHelpful);
     }
+
     conveniencePost.increaseCount(isCorrect);
+
+    return new ConveniencePostInfoResponse(
+        conveniencePost.getCorrectCount(), conveniencePost.getIncorrectCount(), isCorrect);
   }
 
   private User getUserOrThrow(Long userId) {

--- a/src/main/java/com/kkinikong/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/kkinikong/be/global/config/SecurityConfig.java
@@ -65,6 +65,8 @@ public class SecurityConfig {
                     .authenticated()
                     .requestMatchers(HttpMethod.POST, "/api/v1/convenience/post")
                     .authenticated()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/convenience/post/**")
+                    .authenticated()
                     .requestMatchers(HttpMethod.POST, "/api/v1/*/review/*/photo")
                     .authenticated()
                     .requestMatchers(


### PR DESCRIPTION
## 📝 개요

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2451fb36-c8b5-471d-8bf5-e05a1f8fafac" />

## 🛠️ 작업 사항

- 편의점 정보 게시글에 '올바른정보예요/잘못된정보예요' 설정 API 구현 

## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-101](https:///heroine.atlassian.net/browse/SCRUM-nn)

## ✅ 체크리스트

- [ ] 코드 리뷰 반영 완료
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] 문서 업데이트 필요 시 반영

## 🙏 기타 사항

추가적으로 리뷰어가 알아야 할 사항 작성


[SCRUM-101]: https://heroine.atlassian.net/browse/SCRUM-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ