### PR TITLE
[SCRUM-106] Review : 백엔드 개발 세미나 코드 리뷰

### DIFF
--- a/src/main/java/com/kkinikong/be/store/repository/store/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/kkinikong/be/store/repository/store/StoreRepositoryCustomImpl.java
@@ -20,6 +20,7 @@ import com.kkinikong.be.store.domain.Store;
 import com.kkinikong.be.store.domain.type.Category;
 import com.kkinikong.be.store.domain.type.StoreSort;
 
+// 💬 코드 리뷰용 주석 시작
 @RequiredArgsConstructor
 public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
 
@@ -153,3 +154,4 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
     };
   }
 }
+// 💬 코드 리뷰용 주석 종료

--- a/src/main/java/com/kkinikong/be/store/service/StoreCacheService.java
+++ b/src/main/java/com/kkinikong/be/store/service/StoreCacheService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.extern.slf4j.Slf4j;
 
+// 💬 코드 리뷰용 주석 시작
 @Service
 @Slf4j
 public class StoreCacheService {
@@ -37,3 +38,4 @@ public class StoreCacheService {
     redisTemplate.delete(STORE_VIEWS_KEY);
   }
 }
+// 💬 코드 리뷰용 주석 종료

--- a/src/main/java/com/kkinikong/be/store/service/StoreScheduledService.java
+++ b/src/main/java/com/kkinikong/be/store/service/StoreScheduledService.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.kkinikong.be.store.repository.store.StoreRepository;
 
+// 💬 코드 리뷰용 주석 시작
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -37,3 +38,4 @@ public class StoreScheduledService {
     storeCacheService.clearStoresViewCounts();
   }
 }
+// 💬 코드 리뷰용 주석 종료


### PR DESCRIPTION
## 📝 개요

백엔드 개발 세미나 코드 리뷰를 위한 PR입니다.

## 🛠️ 작업 사항

1. 조회수 집계 로직에서의 Redis 사용 : 현재 가맹점 api 호출시마다 Redis의 해시 자료구조에 id와 조회수를 저장하고있습니다. 이후 스케쥴 애노테이션을 통해 1시간마다 데이터베이스에 업데이트하고 캐싱 초기화하는 방식으로 구현했습니다. 이때 동시성 이슈, Redis 용량과 관련한 성능문제, 개선 포인트가 궁금합니다.

2. 다양한 조건에 따라 가맹점 데이터를 유연하게 조회하기 위한 QueryDSL의 사용 
- store과 storeScrap을 tuple로 조회한 후, 찜 여부를 판단해 .setIsScrapped()로 Store 엔티티(@Transiet 필드) 에 직접 값을 세팅하는 구조입니다. 이 방식이 실무적으로 괜찮은지, 혹은 DTO에서만 처리하는 구조가 더 적절한지에 대한 의문입니다.
- 거리 필터링 정렬에 모두 ST_Distance_Sphere을 사용하고 있습니다. 이렇게 동일한 거리 계산 함수를 where과 order by 양쪽에 사용하는 방식이 성능적으로 괜찮은지, 또는 이런 경우에 Spatial 인덱스를 활용하는 게 적절한지도 궁금합니다. 

## 🗂️ 참고 파일
StoreService > StoreCacheService > StoreScheduledService
StoreRepositoryImpl
## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-106](https:///heroine.atlassian.net/browse/SCRUM-nn)




[SCRUM-106]: https://heroine.atlassian.net/browse/SCRUM-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ