### PR TITLE
[SCRUM-119] Feat : 편의점 정보 게시판 리스트 필터링 정렬

### DIFF
--- a/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
+++ b/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
@@ -34,6 +34,9 @@ public class ConvenienceController {
 
   private final ConvenienceService convenienceService;
 
+  private static final String NO_RESULT_WITH_KEYWORD = "NO_RESULT_WITH_KEYWORD";
+  private static final String NO_RESULT = "NO_RESULT";
+
   @GetMapping("/recommendation")
   @Operation(
       summary = "정확한 제품명 추천",
@@ -95,9 +98,8 @@ public class ConvenienceController {
           - 검색어(keyword), 카테고리(category), 브랜드(brand), 사용 가능 여부(isAvailableCheck)로 필터링 및 정렬 할 수 있습니다.
           - 아무것도 선택하지 않을시 기본 정렬은 최신순입니다.
           - 검색어, 카테고리, 브랜드는 선택 사항이며, 기본값은 null입니다.
-          - keyword : 제품이름으로 검색가능하며 글자수 제한 없습니다. 결과가 없을 경우 ~~를 반환합니다.
-          - isAvailableCheck : true인 경우 사용 가능한 제품만 조회하며, 기본값은 false입니다.
-
+          - isAvailableCheck : true인 경우 사용 가능한 제품만 조회하며, 기본값은 false입니다. → 체크안한경우엔 null로 보내셔도 됩니다.
+          - 키워드와 체크박스 여부에 따라 정렬이 달라지며 브랜드는 필터링 역할만 제공합니다.
           """)
   @GetMapping("/list")
   public ResponseEntity<ApiResponse<Object>> getConveniencePostList(
@@ -111,6 +113,14 @@ public class ConvenienceController {
     PageResponse<ConveniencePostListResponse> conveniencePostList =
         convenienceService.getConveniencePostList(
             keyword, category, brand, isAvailableCheck, page, size);
+
+    if (conveniencePostList.content().isEmpty()) {
+      if (keyword != null && !keyword.isBlank()) {
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(NO_RESULT_WITH_KEYWORD));
+      }
+      return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(NO_RESULT));
+    }
+
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(conveniencePostList));
   }
 }

--- a/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
+++ b/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
@@ -14,12 +14,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import com.kkinikong.be.convenience.domain.type.Brand;
+import com.kkinikong.be.convenience.domain.type.Category;
 import com.kkinikong.be.convenience.dto.request.ConveniencePostInfoRequest;
 import com.kkinikong.be.convenience.dto.request.ConvenienceRequest;
 import com.kkinikong.be.convenience.dto.response.ConveniencePostInfoResponse;
+import com.kkinikong.be.convenience.dto.response.ConveniencePostListResponse;
 import com.kkinikong.be.convenience.dto.response.ConveniencePostResponse;
 import com.kkinikong.be.convenience.service.ConvenienceService;
 import com.kkinikong.be.global.response.ApiResponse;
+import com.kkinikong.be.global.response.PageResponse;
 import com.kkinikong.be.user.utils.CustomUserDetails;
 
 @RestController
@@ -82,5 +86,30 @@ public class ConvenienceController {
     ConveniencePostInfoResponse response =
         convenienceService.addConveniencePostInfo(postId, request.isCorrect(), userDetails.getId());
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(response));
+  }
+
+  @Operation(
+      summary = "편의점 정보 게시판 리스트 조회",
+      description =
+          """
+          - 검색어(keyword), 카테고리(category), 브랜드(brand), 사용 가능 여부(isAvailable)로 필터링할 수 있습니다.
+          - 모든 파라미터는 선택 사항이며, 기본값은 null입니다.
+          - keyword : 제품이름으로 검색가능하며 글자수 제한 없습니다. 결과가 없을 경우 ~~ 반환합니다.
+          - 카테고리와 브랜드는 최신순으로 정렬됩니다.
+          - isAvailable : true인 경우 사용 가능한 제품만, false인 경우 사용 불가능한 제품만 조회합니다.
+          """)
+  @GetMapping("/list")
+  public ResponseEntity<ApiResponse<Object>> getConveniencePostList(
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) Category category,
+      @RequestParam(required = false) Brand brand,
+      @RequestParam(required = false) boolean isAvailable,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size) {
+
+    PageResponse<ConveniencePostListResponse> conveniencePostList =
+        convenienceService.getConveniencePostList(
+            keyword, category, brand, isAvailable, page, size);
+    return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(conveniencePostList));
   }
 }

--- a/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
+++ b/src/main/java/com/kkinikong/be/convenience/controller/ConvenienceController.java
@@ -92,24 +92,25 @@ public class ConvenienceController {
       summary = "편의점 정보 게시판 리스트 조회",
       description =
           """
-          - 검색어(keyword), 카테고리(category), 브랜드(brand), 사용 가능 여부(isAvailable)로 필터링할 수 있습니다.
-          - 모든 파라미터는 선택 사항이며, 기본값은 null입니다.
-          - keyword : 제품이름으로 검색가능하며 글자수 제한 없습니다. 결과가 없을 경우 ~~ 반환합니다.
-          - 카테고리와 브랜드는 최신순으로 정렬됩니다.
-          - isAvailable : true인 경우 사용 가능한 제품만, false인 경우 사용 불가능한 제품만 조회합니다.
+          - 검색어(keyword), 카테고리(category), 브랜드(brand), 사용 가능 여부(isAvailableCheck)로 필터링 및 정렬 할 수 있습니다.
+          - 아무것도 선택하지 않을시 기본 정렬은 최신순입니다.
+          - 검색어, 카테고리, 브랜드는 선택 사항이며, 기본값은 null입니다.
+          - keyword : 제품이름으로 검색가능하며 글자수 제한 없습니다. 결과가 없을 경우 ~~를 반환합니다.
+          - isAvailableCheck : true인 경우 사용 가능한 제품만 조회하며, 기본값은 false입니다.
+
           """)
   @GetMapping("/list")
   public ResponseEntity<ApiResponse<Object>> getConveniencePostList(
       @RequestParam(required = false) String keyword,
       @RequestParam(required = false) Category category,
       @RequestParam(required = false) Brand brand,
-      @RequestParam(required = false) boolean isAvailable,
+      @RequestParam(defaultValue = "false") boolean isAvailableCheck,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "10") int size) {
 
     PageResponse<ConveniencePostListResponse> conveniencePostList =
         convenienceService.getConveniencePostList(
-            keyword, category, brand, isAvailable, page, size);
+            keyword, category, brand, isAvailableCheck, page, size);
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(conveniencePostList));
   }
 }

--- a/src/main/java/com/kkinikong/be/convenience/dto/response/ConveniencePostListResponse.java
+++ b/src/main/java/com/kkinikong/be/convenience/dto/response/ConveniencePostListResponse.java
@@ -1,0 +1,10 @@
+package com.kkinikong.be.convenience.dto.response;
+
+import com.kkinikong.be.convenience.domain.ConveniencePost;
+
+public record ConveniencePostListResponse(Long id, String name, boolean isAvailable) {
+  public static ConveniencePostListResponse from(ConveniencePost conveniencePost) {
+    return new ConveniencePostListResponse(
+        conveniencePost.getId(), conveniencePost.getName(), conveniencePost.getIsAvailable());
+  }
+}

--- a/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepository.java
+++ b/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepository.java
@@ -1,16 +1,10 @@
 package com.kkinikong.be.convenience.repository;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.kkinikong.be.convenience.domain.ConveniencePost;
-import com.kkinikong.be.convenience.domain.type.Brand;
 
 @Repository
 public interface ConvenienceRepository
-    extends JpaRepository<ConveniencePost, Long>, ConvenienceRepositoryCustom {
-
-  Page<ConveniencePost> findAllByBrand(Brand brand, Pageable pageable);
-}
+    extends JpaRepository<ConveniencePost, Long>, ConvenienceRepositoryCustom {}

--- a/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepository.java
+++ b/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepository.java
@@ -1,9 +1,16 @@
 package com.kkinikong.be.convenience.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.kkinikong.be.convenience.domain.ConveniencePost;
+import com.kkinikong.be.convenience.domain.type.Brand;
 
 @Repository
-public interface ConvenienceRepository extends JpaRepository<ConveniencePost, Long> {}
+public interface ConvenienceRepository
+    extends JpaRepository<ConveniencePost, Long>, ConvenienceRepositoryCustom {
+
+  Page<ConveniencePost> findAllByBrand(Brand brand, Pageable pageable);
+}

--- a/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepositoryCustom.java
+++ b/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepositoryCustom.java
@@ -1,0 +1,3 @@
+package com.kkinikong.be.convenience.repository;
+
+public interface ConvenienceRepositoryCustom {}

--- a/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepositoryCustom.java
+++ b/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepositoryCustom.java
@@ -1,3 +1,13 @@
 package com.kkinikong.be.convenience.repository;
 
-public interface ConvenienceRepositoryCustom {}
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kkinikong.be.convenience.domain.ConveniencePost;
+import com.kkinikong.be.convenience.domain.type.Brand;
+import com.kkinikong.be.convenience.domain.type.Category;
+
+public interface ConvenienceRepositoryCustom {
+  Page<ConveniencePost> findByCondition(
+      String keyword, Brand brand, Category category, Boolean isAvailableCheck, Pageable pageable);
+}

--- a/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepositoryCustomImpl.java
+++ b/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepositoryCustomImpl.java
@@ -1,0 +1,3 @@
+package com.kkinikong.be.convenience.repository;
+
+public class ConvenienceRepositoryCustomImpl implements ConvenienceRepositoryCustom {}

--- a/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepositoryCustomImpl.java
+++ b/src/main/java/com/kkinikong/be/convenience/repository/ConvenienceRepositoryCustomImpl.java
@@ -1,3 +1,131 @@
 package com.kkinikong.be.convenience.repository;
 
-public class ConvenienceRepositoryCustomImpl implements ConvenienceRepositoryCustom {}
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import com.kkinikong.be.convenience.domain.ConveniencePost;
+import com.kkinikong.be.convenience.domain.QConveniencePost;
+import com.kkinikong.be.convenience.domain.type.Brand;
+import com.kkinikong.be.convenience.domain.type.Category;
+
+@RequiredArgsConstructor
+public class ConvenienceRepositoryCustomImpl implements ConvenienceRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<ConveniencePost> findByCondition(
+      String keyword, Brand brand, Category category, Boolean isAvailableCheck, Pageable pageable) {
+    QConveniencePost conveniencePost = QConveniencePost.conveniencePost;
+
+    List<BooleanExpression> conditions =
+        buildConditions(keyword, brand, category, isAvailableCheck, conveniencePost);
+    List<OrderSpecifier<?>> orderSpecifiers =
+        buildOrderSpecifiers(keyword, isAvailableCheck, conveniencePost);
+
+    List<ConveniencePost> conveniencePosts =
+        fetchConveniencePost(pageable, conveniencePost, conditions, orderSpecifiers);
+    Long totalCount = fetchTotalCount(conveniencePost, conditions);
+
+    return new PageImpl<>(conveniencePosts, pageable, totalCount);
+  }
+
+  // WHERE 조건을 빌드
+  private List<BooleanExpression> buildConditions(
+      String keyword,
+      Brand brand,
+      Category category,
+      Boolean isAvailableCheck,
+      QConveniencePost conveniencePost) {
+    List<BooleanExpression> conditions = new ArrayList<>();
+
+    if (keyword != null && !keyword.isBlank()) {
+      conditions.add(conveniencePost.name.containsIgnoreCase(keyword));
+    }
+    if (brand != null) {
+      conditions.add(conveniencePost.brand.eq(brand));
+    }
+    if (category != null) {
+      conditions.add(conveniencePost.category.eq(category));
+    }
+    if (isAvailableCheck) {
+      conditions.add(conveniencePost.isAvailable.eq(true));
+    }
+    return conditions;
+  }
+
+  // ORDER BY 조건을 빌드 (키워드, isAvailableCheck)
+  private List<OrderSpecifier<?>> buildOrderSpecifiers(
+      String keyword, boolean isAvailableCheck, QConveniencePost conveniencePost) {
+    List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+    if (keyword != null && !keyword.isBlank()) {
+      orderSpecifiers.add(buildKeywordAccuracyOrder(keyword, conveniencePost));
+      orderSpecifiers.add(conveniencePost.name.asc());
+      if (isAvailableCheck) {
+        orderSpecifiers.addAll(buildHelpfulAndDateOrder(conveniencePost));
+      }
+    } else if (isAvailableCheck) {
+      orderSpecifiers.addAll(buildHelpfulAndDateOrder(conveniencePost));
+    } else {
+      orderSpecifiers.add(conveniencePost.createdDate.desc()); // 최신순
+    }
+
+    return orderSpecifiers;
+  }
+
+  // 키워드 정확도에 따른 정렬 조건을 빌드
+  private OrderSpecifier<Integer> buildKeywordAccuracyOrder(
+      String keyword, QConveniencePost conveniencePost) {
+    return Expressions.numberTemplate(
+            Integer.class,
+            "CASE "
+                + "WHEN {0} = {1} THEN 0 " // 정확히 일치하는 경우
+                + "WHEN {0} LIKE {2} THEN 1 " // 포함되는 경우
+                + "ELSE 2 END",
+            conveniencePost.name,
+            keyword,
+            "%" + keyword + "%")
+        .asc();
+  }
+
+  // 도움이 돼요 순 + 최신순으로 정렬하는 조건을 빌드
+  private List<OrderSpecifier<?>> buildHelpfulAndDateOrder(QConveniencePost conveniencePost) {
+    return List.of(conveniencePost.correctCount.desc(), conveniencePost.createdDate.desc());
+  }
+
+  // 데이터 조회
+  private List<ConveniencePost> fetchConveniencePost(
+      Pageable pageable,
+      QConveniencePost conveniencePost,
+      List<BooleanExpression> conditions,
+      List<OrderSpecifier<?>> orderSpecifiers) {
+    return queryFactory
+        .selectFrom(conveniencePost)
+        .where(conditions.toArray(new BooleanExpression[0]))
+        .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+  }
+
+  // ConveniencePost의 총 개수 조회
+  private Long fetchTotalCount(
+      QConveniencePost conveniencePost, List<BooleanExpression> conditions) {
+    return queryFactory
+        .select(conveniencePost.count())
+        .from(conveniencePost)
+        .where(conditions.toArray(new BooleanExpression[0]))
+        .fetchOne();
+  }
+}

--- a/src/main/java/com/kkinikong/be/convenience/service/ConvenienceService.java
+++ b/src/main/java/com/kkinikong/be/convenience/service/ConvenienceService.java
@@ -2,6 +2,9 @@ package com.kkinikong.be.convenience.service;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,8 +13,11 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.kkinikong.be.convenience.domain.ConvenienceHelpful;
 import com.kkinikong.be.convenience.domain.ConveniencePost;
+import com.kkinikong.be.convenience.domain.type.Brand;
+import com.kkinikong.be.convenience.domain.type.Category;
 import com.kkinikong.be.convenience.dto.request.ConvenienceRequest;
 import com.kkinikong.be.convenience.dto.response.ConveniencePostInfoResponse;
+import com.kkinikong.be.convenience.dto.response.ConveniencePostListResponse;
 import com.kkinikong.be.convenience.dto.response.ConveniencePostResponse;
 import com.kkinikong.be.convenience.dto.response.ConvenienceRecommendationResponse;
 import com.kkinikong.be.convenience.exception.ConvenienceException;
@@ -20,6 +26,7 @@ import com.kkinikong.be.convenience.repository.ConvenienceHelpfulRepository;
 import com.kkinikong.be.convenience.repository.ConvenienceRepository;
 import com.kkinikong.be.convenience.util.OpenAIApiClient;
 import com.kkinikong.be.convenience.util.dto.OpenAIRequest;
+import com.kkinikong.be.global.response.PageResponse;
 import com.kkinikong.be.user.domain.User;
 import com.kkinikong.be.user.exception.UserException;
 import com.kkinikong.be.user.exception.errorcode.UserErrorCode;
@@ -105,6 +112,15 @@ public class ConvenienceService {
 
     return new ConveniencePostInfoResponse(
         conveniencePost.getCorrectCount(), conveniencePost.getIncorrectCount(), isCorrect);
+  }
+
+  public PageResponse<ConveniencePostListResponse> getConveniencePostList(
+      String keyword, Category category, Brand brand, boolean isAvailable, int page, int size) {
+    Pageable pageable = PageRequest.of(page, size);
+
+    Page<ConveniencePost> allByBrand = convenienceRepository.findAllByBrand(brand, pageable);
+
+    return PageResponse.from(allByBrand, ConveniencePostListResponse::from);
   }
 
   private User getUserOrThrow(Long userId) {

--- a/src/main/java/com/kkinikong/be/convenience/service/ConvenienceService.java
+++ b/src/main/java/com/kkinikong/be/convenience/service/ConvenienceService.java
@@ -115,10 +115,16 @@ public class ConvenienceService {
   }
 
   public PageResponse<ConveniencePostListResponse> getConveniencePostList(
-      String keyword, Category category, Brand brand, boolean isAvailable, int page, int size) {
+      String keyword,
+      Category category,
+      Brand brand,
+      boolean isAvailableCheck,
+      int page,
+      int size) {
     Pageable pageable = PageRequest.of(page, size);
 
-    Page<ConveniencePost> allByBrand = convenienceRepository.findAllByBrand(brand, pageable);
+    Page<ConveniencePost> allByBrand =
+        convenienceRepository.findByCondition(keyword, brand, category, isAvailableCheck, pageable);
 
     return PageResponse.from(allByBrand, ConveniencePostListResponse::from);
   }


### PR DESCRIPTION
## 📝 개요

편의점 정보게시판 조회 로직을 구현했습니다.
전체 조회와 결제가능 체크박스, 브랜드, 카테고리, 키워드 간의 중복 선택이 가능하도록 작성 완료했습니다.

## 🛠️ 작업 사항
<img width="771" alt="스크린샷 2025-06-04 오후 6 14 36" src="https://github.com/user-attachments/assets/e39c363e-dcf4-4cfa-8041-8ddb427c1993" />

- 편의점 게시판 전체 조회
- 편의점 게시판 정렬 : 도움이 돼요, 최신순, 키워드 일치 정확도
- 편의점 게시판 필터링 : 키워드, 브랜드, 카테고리

## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-119](https:///heroine.atlassian.net/browse/SCRUM-119)

## ✅ 체크리스트

- [ ] 코드 리뷰 반영 완료
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] 문서 업데이트 필요 시 반영

## 🙏 기타 사항

결과가 없는 경우에 message 보내주는 로직을 컨트롤러에 작성했는데 (서비스로직에서 Page로 응답을 주고있어서...) 작동에는 문제없는데 역할분리가 조금 아쉬운것같기도,,,해서 다른방법 추천해줘도 됩니닷ㅎㅎㅎ....


[SCRUM-119]: https://heroine.atlassian.net/browse/SCRUM-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ