### PR TITLE
[SCRUM-188] Feat : 회원 탈퇴 구현 

### DIFF
--- a/src/main/java/com/kkinikong/be/review/service/ReviewService.java
+++ b/src/main/java/com/kkinikong/be/review/service/ReviewService.java
@@ -39,6 +39,7 @@ import com.kkinikong.be.user.domain.User;
 import com.kkinikong.be.user.exception.UserException;
 import com.kkinikong.be.user.exception.errorcode.UserErrorCode;
 import com.kkinikong.be.user.repository.UserRepository;
+import com.kkinikong.be.user.utils.UserNicknameUtil;
 import com.kkinikong.be.util.s3.service.ImageService;
 import com.kkinikong.be.util.s3.type.S3Bucket;
 
@@ -135,7 +136,7 @@ public class ReviewService {
               }
 
               return ReviewItemResponse.from(
-                  reviewUserByReviewIds.get(review.getId()).getNickname(),
+                  UserNicknameUtil.displayNickname(user),
                   review,
                   reviewTagsByReviewIds.get(review.getId()),
                   reviewImageByReviewIds.get(review.getId()),

--- a/src/main/java/com/kkinikong/be/store/repository/storescrap/StoreScrapRepository.java
+++ b/src/main/java/com/kkinikong/be/store/repository/storescrap/StoreScrapRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.kkinikong.be.store.domain.Store;
 import com.kkinikong.be.store.domain.StoreScrap;
@@ -18,6 +19,9 @@ public interface StoreScrapRepository
   Page<StoreScrap> findAllByUserIdOrderByCreatedDateDesc(Long userId, Pageable pageable);
 
   void deleteAllByUser(User user);
+
+  @Query("SELECT ss FROM StoreScrap ss JOIN FETCH ss.store WHERE ss.user = :user")
+  List<StoreScrap> findAllByUser(User user);
 
   Optional<StoreScrap> findByStoreIdAndUserId(Long storeId, Long userId);
 

--- a/src/main/java/com/kkinikong/be/store/repository/storescrap/StoreScrapRepository.java
+++ b/src/main/java/com/kkinikong/be/store/repository/storescrap/StoreScrapRepository.java
@@ -7,10 +7,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kkinikong.be.store.domain.Store;
 import com.kkinikong.be.store.domain.StoreScrap;
+import com.kkinikong.be.user.domain.User;
 
 public interface StoreScrapRepository
     extends JpaRepository<StoreScrap, Long>, StoreScrapRepositoryCustom {
   List<StoreScrap> store(Store store);
+
+  void deleteAllByUser(User user);
 
   Optional<StoreScrap> findByStoreIdAndUserId(Long storeId, Long userId);
 

--- a/src/main/java/com/kkinikong/be/user/controller/UserController.java
+++ b/src/main/java/com/kkinikong/be/user/controller/UserController.java
@@ -50,4 +50,12 @@ public class UserController {
     userService.setUserPlace(userDetails.getId(), request.latitude(), request.longitude());
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
   }
+
+  @Operation(summary = "회원 탈퇴")
+  @DeleteMapping("/me")
+  public ResponseEntity<ApiResponse<Object>> withdraw(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    userService.deleteUser(userDetails.getId());
+    return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+  }
 }

--- a/src/main/java/com/kkinikong/be/user/domain/User.java
+++ b/src/main/java/com/kkinikong/be/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.kkinikong.be.user.domain;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +51,12 @@ public class User extends BaseEntity {
 
   @Column(name = "place_longitude")
   private Double placeLongitude;
+
+  @Column(name = "is_deleted", nullable = false)
+  private boolean isDeleted;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
 
   @Builder(builderMethodName = "socialLoginBuilder", buildMethodName = "buildSocialLogin")
   public User(String email, LoginType loginType) {

--- a/src/main/java/com/kkinikong/be/user/domain/User.java
+++ b/src/main/java/com/kkinikong/be/user/domain/User.java
@@ -3,6 +3,7 @@ package com.kkinikong.be.user.domain;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -83,7 +84,7 @@ public class User extends BaseEntity {
   }
 
   public void withdraw() {
-    this.email = null;
+    this.email = "deleted_" + UUID.randomUUID() + "@deleted.com";
     this.nickname = "Deleted User";
     this.isDeleted = true;
     this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/kkinikong/be/user/domain/User.java
+++ b/src/main/java/com/kkinikong/be/user/domain/User.java
@@ -85,7 +85,7 @@ public class User extends BaseEntity {
 
   public void withdraw() {
     this.email = "deleted_" + UUID.randomUUID() + "@deleted.com";
-    this.nickname = "Deleted User";
+    this.nickname = "DeletedUser_" + UUID.randomUUID().toString().substring(0, 8);
     this.isDeleted = true;
     this.deletedAt = LocalDateTime.now();
   }

--- a/src/main/java/com/kkinikong/be/user/domain/User.java
+++ b/src/main/java/com/kkinikong/be/user/domain/User.java
@@ -82,6 +82,13 @@ public class User extends BaseEntity {
     this.placeLongitude = longitude;
   }
 
+  public void withdraw() {
+    this.email = null;
+    this.nickname = "Deleted User";
+    this.isDeleted = true;
+    this.deletedAt = LocalDateTime.now();
+  }
+
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Review> reviewList = new ArrayList<>();
 

--- a/src/main/java/com/kkinikong/be/user/domain/User.java
+++ b/src/main/java/com/kkinikong/be/user/domain/User.java
@@ -88,6 +88,8 @@ public class User extends BaseEntity {
     this.nickname = "DeletedUser_" + UUID.randomUUID().toString().substring(0, 8);
     this.isDeleted = true;
     this.deletedAt = LocalDateTime.now();
+    this.placeLatitude = null;
+    this.placeLongitude = null;
   }
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/kkinikong/be/user/exception/errorcode/UserErrorCode.java
+++ b/src/main/java/com/kkinikong/be/user/exception/errorcode/UserErrorCode.java
@@ -15,6 +15,7 @@ public enum UserErrorCode implements ErrorCode {
   INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "잘못된 계정 정보입니다."),
   DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
   USER_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+  USER_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 탈퇴한 유저입니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/kkinikong/be/user/service/UserService.java
+++ b/src/main/java/com/kkinikong/be/user/service/UserService.java
@@ -1,7 +1,6 @@
 package com.kkinikong.be.user.service;
 
-import static com.kkinikong.be.user.exception.errorcode.UserErrorCode.DUPLICATE_NICKNAME;
-import static com.kkinikong.be.user.exception.errorcode.UserErrorCode.USER_NOT_FOUND;
+import static com.kkinikong.be.user.exception.errorcode.UserErrorCode.*;
 
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/kkinikong/be/user/service/UserService.java
+++ b/src/main/java/com/kkinikong/be/user/service/UserService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
+import com.kkinikong.be.store.repository.storescrap.StoreScrapRepository;
 import com.kkinikong.be.user.domain.User;
 import com.kkinikong.be.user.domain.type.LoginType;
 import com.kkinikong.be.user.dto.request.NicknameRequest;
@@ -19,6 +20,7 @@ import com.kkinikong.be.user.repository.UserRepository;
 @RequiredArgsConstructor
 public class UserService {
   private final UserRepository userRepository;
+  private final StoreScrapRepository storeScrapRepository;
 
   public User findOrCreateUser(String email, LoginType loginType) {
     return userRepository
@@ -60,6 +62,7 @@ public class UserService {
     if (user.isDeleted()) {
       throw new UserException(USER_ALREADY_DELETED);
     }
+    storeScrapRepository.deleteAllByUser(user);
     user.withdraw();
   }
 

--- a/src/main/java/com/kkinikong/be/user/service/UserService.java
+++ b/src/main/java/com/kkinikong/be/user/service/UserService.java
@@ -59,7 +59,7 @@ public class UserService {
   public void deleteUser(Long userId) {
     User user = getUserOrThrow(userId);
     if (user.isDeleted()) {
-      throw new UserException(USER_NOT_FOUND);
+      throw new UserException(USER_ALREADY_DELETED);
     }
     user.withdraw();
   }

--- a/src/main/java/com/kkinikong/be/user/service/UserService.java
+++ b/src/main/java/com/kkinikong/be/user/service/UserService.java
@@ -55,6 +55,15 @@ public class UserService {
     user.updatePlace(latitude, longitude);
   }
 
+  @Transactional
+  public void deleteUser(Long userId) {
+    User user = getUserOrThrow(userId);
+    if (user.isDeleted()) {
+      throw new UserException(USER_NOT_FOUND);
+    }
+    user.withdraw();
+  }
+
   private User getUserOrThrow(Long userId) {
     return userRepository
         .findById(userId)

--- a/src/main/java/com/kkinikong/be/user/service/UserService.java
+++ b/src/main/java/com/kkinikong/be/user/service/UserService.java
@@ -2,11 +2,15 @@ package com.kkinikong.be.user.service;
 
 import static com.kkinikong.be.user.exception.errorcode.UserErrorCode.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
+import com.kkinikong.be.store.domain.Store;
+import com.kkinikong.be.store.domain.StoreScrap;
 import com.kkinikong.be.store.repository.storescrap.StoreScrapRepository;
 import com.kkinikong.be.user.domain.User;
 import com.kkinikong.be.user.domain.type.LoginType;
@@ -61,6 +65,11 @@ public class UserService {
     User user = getUserOrThrow(userId);
     if (user.isDeleted()) {
       throw new UserException(USER_ALREADY_DELETED);
+    }
+    List<StoreScrap> scrapList = storeScrapRepository.findAllByUser(user);
+    for (StoreScrap scrap : scrapList) {
+      Store store = scrap.getStore();
+      store.decreaseScrapCount();
     }
     storeScrapRepository.deleteAllByUser(user);
     user.withdraw();

--- a/src/main/java/com/kkinikong/be/user/utils/UserNicknameUtil.java
+++ b/src/main/java/com/kkinikong/be/user/utils/UserNicknameUtil.java
@@ -4,6 +4,6 @@ import com.kkinikong.be.user.domain.User;
 
 public class UserNicknameUtil {
   public static String displayNickname(User user) {
-    return user.isDeleted() ? "탈퇴한 회원입니다." : user.getNickname();
+    return user.isDeleted() ? "탈퇴한 회원입니다" : user.getNickname();
   }
 }

--- a/src/main/java/com/kkinikong/be/user/utils/UserNicknameUtil.java
+++ b/src/main/java/com/kkinikong/be/user/utils/UserNicknameUtil.java
@@ -1,0 +1,9 @@
+package com.kkinikong.be.user.utils;
+
+import com.kkinikong.be.user.domain.User;
+
+public class UserNicknameUtil {
+  public static String displayNickname(User user) {
+    return user.isDeleted() ? "탈퇴한 회원입니다." : user.getNickname();
+  }
+}


### PR DESCRIPTION
## 📝 개요
회원 탈퇴를 구현했습니다. 

## 🛠️ 작업 사항
- 기획 > 회원 탈퇴 노션 기준으로 회원 탈퇴 시 **Soft Delete** 방식을 채택했습니다.
   - 이메일: `"deleted_" + UUID + "@deleted.com"` 형태로 변경
   - 닉네임: "DeletedUser_" + UUID 로 변경
   - `is_deleted` → true, `deleted_at` → 현재 시간
> ![image](https://github.com/user-attachments/assets/e40a0d21-cd47-4557-a231-27b2bc0d7c03)
   


- 다음과 같이 탈퇴한 유저의 닉네임이 '탈퇴한 회원입니다' 라고 나타내기 위해서 `UserNicknameUtil` 을 만들었습니다. 
> ![image](https://github.com/user-attachments/assets/b1e8607c-182a-4348-9614-1d162e1d4b19)

![image](https://github.com/user-attachments/assets/b0a52994-9ac3-4e3a-acde-2d82c66130e0)

- 유저가 탈퇴할 경우 다른 정보들(커뮤니티의 좋아요, 편의점 게시판에서 도움이 돼요)은 다 남아있고, 스크랩 정보만 삭제하도록 진행했습니다. 


## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-188](https:///heroine.atlassian.net/browse/SCRUM-nn)

## ✅ 체크리스트

- [ ] 코드 리뷰 반영 완료
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] 문서 업데이트 필요 시 반영

## 🙏 기타 사항
> 추후에 커뮤니티 게시글, 댓글, 답글에서 유저의 닉네임을 보여주는 경우 `UserNicknameUtil` 에 있는 `displayNickname` 메서드를 사용하면 될 것 같아요~ 지금은 리뷰 부분에는 적용해놓았습니다. 


[SCRUM-188]: https://heroine.atlassian.net/browse/SCRUM-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ