### PR TITLE
[SCRUM-241] Feat : 닉네임 수정 API 구현 

### DIFF
--- a/src/main/java/com/kkinikong/be/user/controller/UserController.java
+++ b/src/main/java/com/kkinikong/be/user/controller/UserController.java
@@ -43,6 +43,15 @@ public class UserController {
     return ResponseEntity.ok(ApiResponse.from(isDuplicated));
   }
 
+  @Operation(summary = "닉네임 수정")
+  @PatchMapping("/nickname")
+  public ResponseEntity<ApiResponse<Object>> updateNickname(
+      @Valid @RequestBody NicknameRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    userService.updateNickname(request, userDetails.getId());
+    return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+  }
+
   @Operation(summary = "유저가 자주 가는 지역 설정")
   @PostMapping("/place")
   public ResponseEntity<ApiResponse<Object>> userPlace(

--- a/src/main/java/com/kkinikong/be/user/controller/UserController.java
+++ b/src/main/java/com/kkinikong/be/user/controller/UserController.java
@@ -48,7 +48,7 @@ public class UserController {
   public ResponseEntity<ApiResponse<Object>> updateNickname(
       @Valid @RequestBody NicknameRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-    userService.addNickname(request, userDetails.getId());
+    userService.updateNickname(request, userDetails.getId());
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
   }
 

--- a/src/main/java/com/kkinikong/be/user/controller/UserController.java
+++ b/src/main/java/com/kkinikong/be/user/controller/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
       @Valid @RequestBody NicknameRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-    NicknameResponse response = userService.updateNickname(request, userDetails.getId());
+    NicknameResponse response = userService.addNickname(request, userDetails.getId());
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(response));
   }
 
@@ -48,7 +48,7 @@ public class UserController {
   public ResponseEntity<ApiResponse<Object>> updateNickname(
       @Valid @RequestBody NicknameRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-    userService.updateNickname(request, userDetails.getId());
+    userService.addNickname(request, userDetails.getId());
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
   }
 

--- a/src/main/java/com/kkinikong/be/user/domain/User.java
+++ b/src/main/java/com/kkinikong/be/user/domain/User.java
@@ -59,8 +59,8 @@ public class User extends BaseEntity {
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
-  @Column(name = "is_modified", nullable = false)
-  private boolean isModified = false;
+  @Column(name = "is_nickname_modified", nullable = false)
+  private boolean isNicknameModified = false;
 
   @Builder(builderMethodName = "socialLoginBuilder", buildMethodName = "buildSocialLogin")
   public User(String email, LoginType loginType) {
@@ -84,6 +84,10 @@ public class User extends BaseEntity {
   public void updatePlace(Double latitude, Double longitude) {
     this.placeLatitude = latitude;
     this.placeLongitude = longitude;
+  }
+
+  public void setNicknameModified(boolean modified) {
+    this.isNicknameModified = modified;
   }
 
   public void withdraw() {

--- a/src/main/java/com/kkinikong/be/user/domain/User.java
+++ b/src/main/java/com/kkinikong/be/user/domain/User.java
@@ -59,6 +59,9 @@ public class User extends BaseEntity {
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
+  @Column(name = "is_modified", nullable = false)
+  private boolean isModified = false;
+
   @Builder(builderMethodName = "socialLoginBuilder", buildMethodName = "buildSocialLogin")
   public User(String email, LoginType loginType) {
     this.email = email;

--- a/src/main/java/com/kkinikong/be/user/exception/errorcode/UserErrorCode.java
+++ b/src/main/java/com/kkinikong/be/user/exception/errorcode/UserErrorCode.java
@@ -16,6 +16,7 @@ public enum UserErrorCode implements ErrorCode {
   DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
   USER_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
   USER_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 탈퇴한 유저입니다."),
+  NICKNAME_ALREADY_MODIFIED(HttpStatus.BAD_REQUEST, "이미 닉네임을 변경하였습니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/kkinikong/be/user/service/UserService.java
+++ b/src/main/java/com/kkinikong/be/user/service/UserService.java
@@ -57,7 +57,7 @@ public class UserService {
 
   public void updateNickname(NicknameRequest request, Long userId) {
     User user = getUserOrThrow(userId);
-    if (user.isModified()) {
+    if (user.isNicknameModified()) {
       throw new UserException(NICKNAME_ALREADY_MODIFIED);
     }
     user.updateNickname(request.nickname());

--- a/src/main/java/com/kkinikong/be/user/service/UserService.java
+++ b/src/main/java/com/kkinikong/be/user/service/UserService.java
@@ -40,14 +40,12 @@ public class UserService {
   }
 
   public NicknameResponse addNickname(NicknameRequest request, Long userId) {
-    User user =
-        userRepository.findById(userId).orElseThrow(() -> new UserException(USER_NOT_FOUND));
+    User user = getUserOrThrow(userId);
     if (userRepository.existsByNickname(request.nickname())) {
       throw new UserException(DUPLICATE_NICKNAME);
     }
     user.updateNickname(request.nickname());
     userRepository.save(user);
-
     return new NicknameResponse(user.getEmail(), request.nickname());
   }
 
@@ -55,6 +53,7 @@ public class UserService {
     return userRepository.existsByNickname(nickname);
   }
 
+  @Transactional
   public void updateNickname(NicknameRequest request, Long userId) {
     User user = getUserOrThrow(userId);
     if (user.isNicknameModified()) {

--- a/src/main/java/com/kkinikong/be/user/service/UserService.java
+++ b/src/main/java/com/kkinikong/be/user/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
                         .buildSocialLogin()));
   }
 
-  public NicknameResponse updateNickname(NicknameRequest request, Long userId) {
+  public NicknameResponse addNickname(NicknameRequest request, Long userId) {
     User user =
         userRepository.findById(userId).orElseThrow(() -> new UserException(USER_NOT_FOUND));
     if (userRepository.existsByNickname(request.nickname())) {

--- a/src/main/java/com/kkinikong/be/user/service/UserService.java
+++ b/src/main/java/com/kkinikong/be/user/service/UserService.java
@@ -45,7 +45,6 @@ public class UserService {
       throw new UserException(DUPLICATE_NICKNAME);
     }
     user.updateNickname(request.nickname());
-    userRepository.save(user);
     return new NicknameResponse(user.getEmail(), request.nickname());
   }
 

--- a/src/main/java/com/kkinikong/be/user/service/UserService.java
+++ b/src/main/java/com/kkinikong/be/user/service/UserService.java
@@ -55,6 +55,15 @@ public class UserService {
     return userRepository.existsByNickname(nickname);
   }
 
+  public void updateNickname(NicknameRequest request, Long userId) {
+    User user = getUserOrThrow(userId);
+    if (user.isModified()) {
+      throw new UserException(NICKNAME_ALREADY_MODIFIED);
+    }
+    user.updateNickname(request.nickname());
+    user.setNicknameModified(true);
+  }
+
   @Transactional
   public void setUserPlace(Long userId, Double latitude, Double longitude) {
     User user = getUserOrThrow(userId);


### PR DESCRIPTION
## 📝 개요
닉네임 수정 API 를 구현했습니다. 

## 🛠️ 작업 사항
기존에는 닉네임 등록 API와 함께 사용할 수 있을 것이라고 판단했는데, 닉네임 수정은 1회만 가능한 상황이라고 하셔서 별도의 API를 만들었습니다.

## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-241](https:///heroine.atlassian.net/browse/SCRUM-nn)

## ✅ 체크리스트

- [ ] 코드 리뷰 반영 완료
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] 문서 업데이트 필요 시 반영

## 🙏 기타 사항

> 추가적으로 리뷰어가 알아야 할 사항 작성


[SCRUM-241]: https://heroine.atlassian.net/browse/SCRUM-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ