### PR TITLE
[SCRUM-287] Fix : 내가 좋아요 누른 게시글 조회에서 '게시글' 기준 최신순 정렬 하도록 수정

### DIFF
--- a/src/main/java/com/kkinikong/be/community/repository/CommunityPostLikeRepository.java
+++ b/src/main/java/com/kkinikong/be/community/repository/CommunityPostLikeRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.kkinikong.be.community.domain.CommunityPostLike;
@@ -20,7 +21,13 @@ public interface CommunityPostLikeRepository extends JpaRepository<CommunityPost
         "communityPost.user",
         "communityPost.communityPostImageList"
       })
-  Page<CommunityPostLike> findAllByUserIdOrderByCreatedDateDesc(Long userId, Pageable pageable);
+  @Query(
+      """
+    SELECT cpl FROM CommunityPostLike cpl
+    WHERE cpl.user.id = :userId
+    ORDER BY cpl.communityPost.createdDate DESC
+""")
+  Page<CommunityPostLike> findAllByUserId(Long userId, Pageable pageable);
 
   void deleteAllByCommunityPostId(Long postId);
 }

--- a/src/main/java/com/kkinikong/be/user/service/MypageService.java
+++ b/src/main/java/com/kkinikong/be/user/service/MypageService.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -85,9 +86,9 @@ public class MypageService {
   }
 
   public PageResponse<CommunityPostListResponse> getLikePost(Long userId, int page, int size) {
-    Pageable pageable = PageRequest.of(page, size);
+    Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdDate"));
     Page<CommunityPostLike> communityPostListPage =
-        communityPostLikeRepository.findAllByUserIdOrderByCreatedDateDesc(userId, pageable);
+        communityPostLikeRepository.findAllByUserId(userId, pageable);
     return PageResponse.from(
         communityPostListPage, like -> CommunityPostListResponse.from(like.getCommunityPost()));
   }


### PR DESCRIPTION
## 📝 개요
' 내가 좋아요한 게시글 조회' 시 게시글 작성일 기준 최신순 정렬이 되지 않는 문제를 해결했습니다. 

## 🛠️ 작업 사항

원인 : Repository 메서드에 `OrderByCreatedDesc` 를 사용하고 있었으나, `PageRequest(page, size)` 에는 정렬이 포함되지 않아 메서드 이름 기반 정렬이 무시되는 상황이라서 적용이 안되었음 

수정 : @Query를 사용하여 communityPost.createdDate 기준으로 정렬 지정 

## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-287](https:///heroine.atlassian.net/browse/SCRUM-nn)

## ✅ 체크리스트

- [ ] 코드 리뷰 반영 완료
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] 문서 업데이트 필요 시 반영

## 🙏 기타 사항
> 추가적으로 리뷰어가 알아야 할 사항 작성


[SCRUM-287]: https://heroine.atlassian.net/browse/SCRUM-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ