### PR TITLE
[SCRUM-314] Fix: CI 수정

### DIFF
--- a/.github/workflows/kkinikong-be-cd.yml
+++ b/.github/workflows/kkinikong-be-cd.yml
@@ -34,10 +34,15 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: 🐳 Docker 이미지 빌드 & Push
-        run: |
-          docker build -t chaeeunkim/kkini-kong-be:develop .
-          docker push chaeeunkim/kkini-kong-be:develop
+      - name: 🏷️ Docker 이미지 빌드 & Push (develop 태그)
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            chaeeunkim/kkini-kong-be:develop
           
       - name: 🚀 EC2 서버에 SSH 접속 후 Blue-Green 배포
         uses: appleboy/ssh-action@master

--- a/.github/workflows/kkinikong-be-ci.yml
+++ b/.github/workflows/kkinikong-be-ci.yml
@@ -34,4 +34,4 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: ✅ 테스트 및 빌드 확인
-        run: ./gradlew clean build --info
+        run: ./gradlew clean build --exclude-task test --info

--- a/.github/workflows/kkinikong-be-ci.yml
+++ b/.github/workflows/kkinikong-be-ci.yml
@@ -2,10 +2,9 @@ name: ✨ Kkini-kong CI ✨
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened] 
+    types: [opened, synchronize, reopened]
     branches:
       - develop
-
 
 jobs:
   docker-build-and-push:
@@ -34,21 +33,5 @@ jobs:
       - name: 📝 Gradlew 권한 설정
         run: chmod +x ./gradlew
 
-      - name: 🏗️ Jar 빌드
-        run: ./gradlew bootJar
-
-      - name: 🔑 DockerHub 로그인
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: 🏷️ Docker 이미지 빌드 & Push (develop 태그)
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          platforms: linux/amd64
-          tags: |
-            chaeeunkim/kkini-kong-be:develop
+      - name: ✅ 테스트 및 빌드 확인
+        run: ./gradlew clean build --info


### PR DESCRIPTION
## 📝 개요

CI, CD를 수정했습니다.

## 🛠️ 작업 사항

- "PR 1 → CI 실행 → PR 2 → CI 실행 → PR 1이 머지되어 CD 실행 → PR 2의 이미지가 배포됨"
기존에는 위와 같은 문제가 있었는데 develop 브랜치에 병합된 PR이 아닌 최신 푸시된 이미지가 배포되는 구조였습니다.
- 기존 CI에서는 이미지 빌드까지 했는데 이부분은 삭제하고 빌드까지만 확인하도록 변경했습니다.
- CD에서는 항상 develop 브랜치에서 이미지를 빌드하고 배포하도록 변경했습니다. (develop에 이미 반영)

## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-nn](https:///heroine.atlassian.net/browse/SCRUM-nn)

## ✅ 체크리스트

- [ ] 코드 리뷰 반영 완료
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] 문서 업데이트 필요 시 반영

## 🙏 기타 사항

추가적으로 리뷰어가 알아야 할 사항 작성
