### PR TITLE
[SCRUM-341] Refactor: 외부링크를 모바일, 웹 두개 버전으로 분리

### DIFF
--- a/src/main/java/com/kkinikong/be/store/dto/response/StoreExternalLinkResponse.java
+++ b/src/main/java/com/kkinikong/be/store/dto/response/StoreExternalLinkResponse.java
@@ -3,4 +3,5 @@ package com.kkinikong.be.store.dto.response;
 import lombok.Builder;
 
 @Builder
-public record StoreExternalLinkResponse(String menuUrl, String directionUrl) {}
+public record StoreExternalLinkResponse(
+    String menuUrl, String directionUrlMobile, String directionUrlDesktop) {}

--- a/src/main/java/com/kkinikong/be/store/service/StoreService.java
+++ b/src/main/java/com/kkinikong/be/store/service/StoreService.java
@@ -134,7 +134,8 @@ public class StoreService {
 
     return StoreExternalLinkResponse.builder()
         .menuUrl(hasInfo ? buildMenuUrl(kakaoPlaceId) : buildNaverUrl(store.getName()))
-        .directionUrl(hasInfo ? buildDirectionUrl(kakaoPlaceId) : buildNaverUrl(store.getName()))
+        .directionUrlMobile(buildDirectionUrlMobile(store))
+        .directionUrlDesktop(buildDirectionUrlDesktop(store))
         .build();
   }
 
@@ -144,18 +145,6 @@ public class StoreService {
       kakaoPlaceId = NO_INFO;
     }
     return kakaoPlaceId;
-  }
-
-  private String buildDirectionUrl(String placeId) {
-    return "https://map.kakao.com/link/to/" + placeId;
-  }
-
-  private String buildMenuUrl(String placeId) {
-    return "https://place.map.kakao.com/" + placeId + "#menuInfo";
-  }
-
-  private String buildNaverUrl(String placeName) {
-    return "https://map.naver.com/v5/search/" + placeName;
   }
 
   public List<StoreCardResponse> getTopViewedStores(Double latitude, Double longitude) {
@@ -204,5 +193,32 @@ public class StoreService {
     return storeScrapRepository
         .findByStoreIdAndUserId(storeId, userId)
         .orElseThrow(() -> new StoreException(StoreErrorCode.SCRAP_NOT_FOUND));
+  }
+
+  private String buildDirectionUrlMobile(Store store) {
+    return "nmap://route/public?dlat="
+        + store.getLatitude()
+        + "&dlng="
+        + store.getLongitude()
+        + "&dname="
+        + store.getName();
+  }
+
+  private String buildDirectionUrlDesktop(Store store) {
+    return "m.map.naver.com/route.nhn?menu=route&ename="
+        + store.getName()
+        + "&ex="
+        + store.getLongitude()
+        + "&ey="
+        + store.getLatitude()
+        + "&pathType=1&showMap=true";
+  }
+
+  private String buildMenuUrl(String placeId) {
+    return "https://place.map.kakao.com/" + placeId + "#menuInfo";
+  }
+
+  private String buildNaverUrl(String placeName) {
+    return "https://map.naver.com/v5/search/" + placeName;
   }
 }


### PR DESCRIPTION
## 📝 개요

외부링크를 모바일, 웹 두개 버전으로 분리하였습니다.
(메뉴 링크는 그대로)

## 🛠️ 작업 사항

<img width="1093" height="229" alt="스크린샷 2025-07-30 오후 5 03 31" src="https://github.com/user-attachments/assets/34a3820c-6cdb-450b-9389-776595b5d4b2" />
프론트측에서 모바일, 데탑 환경 구분이 가능하다고 하셔서 요렇게 보내도록 설정했습니다!

## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-341](https:///heroine.atlassian.net/browse/SCRUM-341)

## ✅ 체크리스트

- [ ] 코드 리뷰 반영 완료
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] 문서 업데이트 필요 시 반영

## 🙏 기타 사항

추가적으로 리뷰어가 알아야 할 사항 작성


[SCRUM-341]: https://heroine.atlassian.net/browse/SCRUM-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ