### PR TITLE
[SCRUM-364] Refactor : 편의점 응답 및 기타 수정

### DIFF
--- a/src/main/java/com/kkinikong/be/auth/controller/AuthController.java
+++ b/src/main/java/com/kkinikong/be/auth/controller/AuthController.java
@@ -37,17 +37,6 @@ public class AuthController {
   }
 
   @Operation(
-      summary = "기본 회원가입",
-      description = "(관리자) 이메일과 비밀번호로 회원가입합니다. '@'를 포함한 이메일과 비밀번호를 입력해주세요.")
-  @PostMapping("/signup")
-  public ResponseEntity<ApiResponse<Object>> signUp(
-      @Valid @RequestBody BasicLoginRequest basicLoginRequest) {
-
-    authService.signup(basicLoginRequest);
-    return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
-  }
-
-  @Operation(
       summary = "기본 로그인",
       description = "(관리자) 이메일과 비밀번호로 로그인합니다. '@'를 포함한 이메일과 비밀번호를 입력해주세요.")
   @PostMapping("/login")

--- a/src/main/java/com/kkinikong/be/auth/controller/SignupController.java
+++ b/src/main/java/com/kkinikong/be/auth/controller/SignupController.java
@@ -1,0 +1,39 @@
+package com.kkinikong.be.auth.controller;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import com.kkinikong.be.auth.dto.request.BasicLoginRequest;
+import com.kkinikong.be.auth.service.AuthService;
+import com.kkinikong.be.global.response.ApiResponse;
+
+@Profile({"local"})
+@RequestMapping("/api/v1/auth")
+@Tag(name = "Auth 로컬", description = "인증 및 회원 관련 API")
+@RestController
+@RequiredArgsConstructor
+public class SignupController {
+
+  private final AuthService authService;
+
+  @Operation(
+      summary = "기본 회원가입",
+      description = "(관리자) 이메일과 비밀번호로 회원가입합니다. '@'를 포함한 이메일과 비밀번호를 입력해주세요.")
+  @PostMapping("/signup")
+  public ResponseEntity<ApiResponse<Object>> signUp(
+      @Valid @RequestBody BasicLoginRequest basicLoginRequest) {
+
+    authService.signup(basicLoginRequest);
+    return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+  }
+}

--- a/src/main/java/com/kkinikong/be/cache/service/RedisTemplateCacheService.java
+++ b/src/main/java/com/kkinikong/be/cache/service/RedisTemplateCacheService.java
@@ -13,7 +13,7 @@ import com.kkinikong.be.cache.type.RedisKey;
 
 @Service
 @Slf4j
-public class RedisTempleCacheService {
+public class RedisTemplateCacheService {
 
   @Autowired private RedisTemplate<String, Object> redisTemplate;
 

--- a/src/main/java/com/kkinikong/be/cache/service/ScheduledService.java
+++ b/src/main/java/com/kkinikong/be/cache/service/ScheduledService.java
@@ -18,7 +18,7 @@ import com.kkinikong.be.store.repository.store.StoreRepository;
 @RequiredArgsConstructor
 public class ScheduledService {
 
-  private final RedisTempleCacheService redisTempleCacheService;
+  private final RedisTemplateCacheService redisTemplateCacheService;
   private final StoreRepository storeRepository;
   private final CommunityPostRepository communityPostRepository;
 
@@ -26,7 +26,7 @@ public class ScheduledService {
   @Transactional
   public void syncStoreViewCount() {
     Map<Object, Object> storesViewCounts =
-        redisTempleCacheService.getViewCounts(RedisKey.STORE_VIEWS_KEY);
+        redisTemplateCacheService.getViewCounts(RedisKey.STORE_VIEWS_KEY);
     if (storesViewCounts == null || storesViewCounts.isEmpty()) {
       return;
     }
@@ -38,14 +38,14 @@ public class ScheduledService {
           storeRepository.incrementViews(storeId, viewCount);
         });
 
-    redisTempleCacheService.clearViewCounts(RedisKey.STORE_VIEWS_KEY);
+    redisTemplateCacheService.clearViewCounts(RedisKey.STORE_VIEWS_KEY);
   }
 
   @Scheduled(cron = "0 10 * * * *") // 매시간 10분에 실행
   @Transactional
   public void syncCommunityPostViewCount() {
     Map<Object, Object> communityPostsViewCounts =
-        redisTempleCacheService.getViewCounts(RedisKey.COMMUNITY_POST_VIEWS_KEY);
+        redisTemplateCacheService.getViewCounts(RedisKey.COMMUNITY_POST_VIEWS_KEY);
     if (communityPostsViewCounts == null || communityPostsViewCounts.isEmpty()) {
       return;
     }
@@ -57,6 +57,6 @@ public class ScheduledService {
           communityPostRepository.incrementViews(storeId, viewCount);
         });
 
-    redisTempleCacheService.clearViewCounts(RedisKey.COMMUNITY_POST_VIEWS_KEY);
+    redisTemplateCacheService.clearViewCounts(RedisKey.COMMUNITY_POST_VIEWS_KEY);
   }
 }

--- a/src/main/java/com/kkinikong/be/community/domain/Comment.java
+++ b/src/main/java/com/kkinikong/be/community/domain/Comment.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -67,6 +68,8 @@ public class Comment extends BaseEntity {
 
   @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Comment> childComments = new ArrayList<>();
+
+  @Version private Long version;
 
   @Builder
   public Comment(

--- a/src/main/java/com/kkinikong/be/community/domain/CommunityPost.java
+++ b/src/main/java/com/kkinikong/be/community/domain/CommunityPost.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -72,6 +73,8 @@ public class CommunityPost extends BaseEntity {
 
   @OneToMany(mappedBy = "communityPost", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Comment> commentList = new ArrayList<>();
+
+  @Version private Long version;
 
   @Builder
   public CommunityPost(String title, String content, User user, Category category) {

--- a/src/main/java/com/kkinikong/be/community/dto/response/CommentListResponse.java
+++ b/src/main/java/com/kkinikong/be/community/dto/response/CommentListResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 import lombok.Builder;
 
 import com.kkinikong.be.community.domain.Comment;
-import com.kkinikong.be.community.util.TimeUtil;
+import com.kkinikong.be.global.util.TimeUtil;
 import com.kkinikong.be.user.utils.UserNicknameUtil;
 
 @Builder

--- a/src/main/java/com/kkinikong/be/community/dto/response/CommunityPostInfoResponse.java
+++ b/src/main/java/com/kkinikong/be/community/dto/response/CommunityPostInfoResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 import lombok.Builder;
 
 import com.kkinikong.be.community.domain.CommunityPost;
-import com.kkinikong.be.community.util.TimeUtil;
+import com.kkinikong.be.global.util.TimeUtil;
 import com.kkinikong.be.user.utils.UserNicknameUtil;
 
 @Builder

--- a/src/main/java/com/kkinikong/be/community/dto/response/CommunityPostListResponse.java
+++ b/src/main/java/com/kkinikong/be/community/dto/response/CommunityPostListResponse.java
@@ -1,7 +1,7 @@
 package com.kkinikong.be.community.dto.response;
 
 import com.kkinikong.be.community.domain.CommunityPost;
-import com.kkinikong.be.community.util.TimeUtil;
+import com.kkinikong.be.global.util.TimeUtil;
 
 public record CommunityPostListResponse(
     long communityPostId,

--- a/src/main/java/com/kkinikong/be/community/exception/errorcode/CommunityErrorCode.java
+++ b/src/main/java/com/kkinikong/be/community/exception/errorcode/CommunityErrorCode.java
@@ -21,7 +21,8 @@ public enum CommunityErrorCode implements ErrorCode {
   NOT_TOP_COMMENT(HttpStatus.BAD_REQUEST, "최상위 댓글이 아닙니다."),
   COMMENT_NOT_OWNER(HttpStatus.FORBIDDEN, "댓글의 작성자가 아닙니다."),
   COMMENT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 댓글입니다."),
-  ;
+
+  RETRY_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "재시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.");
   private final HttpStatus httpStatus;
   private final String message;
 }

--- a/src/main/java/com/kkinikong/be/community/repository/comment/CommentRepository.java
+++ b/src/main/java/com/kkinikong/be/community/repository/comment/CommentRepository.java
@@ -1,16 +1,10 @@
 package com.kkinikong.be.community.repository.comment;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import io.lettuce.core.dynamic.annotation.Param;
-import jakarta.persistence.LockModeType;
 
 import com.kkinikong.be.community.domain.Comment;
 
@@ -19,10 +13,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
   @EntityGraph(attributePaths = {"commentLikeList", "commentLikeList.user"})
   List<Comment> findAllByCommunityPostId(Long postId);
-
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @Query("SELECT c FROM Comment c WHERE c.id = :commentId")
-  Optional<Comment> findByIdForUpdate(@Param("commentId") Long commentId);
-
-  void deleteAllByCommunityPostId(Long postId);
 }

--- a/src/main/java/com/kkinikong/be/community/repository/communityPost/CommunityPostRepository.java
+++ b/src/main/java/com/kkinikong/be/community/repository/communityPost/CommunityPostRepository.java
@@ -2,19 +2,16 @@ package com.kkinikong.be.community.repository.communityPost;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import io.lettuce.core.dynamic.annotation.Param;
-import jakarta.persistence.LockModeType;
 
 import com.kkinikong.be.community.domain.CommunityPost;
 import com.kkinikong.be.community.domain.type.Category;
@@ -41,10 +38,6 @@ public interface CommunityPostRepository
   Page<CommunityPost> findAll(Pageable pageable);
 
   Page<CommunityPost> findAllByUserIdOrderByCreatedDateDesc(Long userId, Pageable pageable);
-
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @Query("SELECT p FROM CommunityPost p WHERE p.id = :postId")
-  Optional<CommunityPost> findByIdForUpdate(@Param("postId") Long postId);
 
   @Modifying(clearAutomatically = true)
   @Query("UPDATE CommunityPost p SET p.viewCount = p.viewCount + :count WHERE p.id = :postId")

--- a/src/main/java/com/kkinikong/be/community/service/CommunityLikeToggleExecutor.java
+++ b/src/main/java/com/kkinikong/be/community/service/CommunityLikeToggleExecutor.java
@@ -1,0 +1,65 @@
+package com.kkinikong.be.community.service;
+
+import java.util.Optional;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.kkinikong.be.community.domain.CommunityPost;
+import com.kkinikong.be.community.domain.CommunityPostLike;
+import com.kkinikong.be.community.dto.response.LikeToggleResponse;
+import com.kkinikong.be.community.exception.CommunityException;
+import com.kkinikong.be.community.exception.errorcode.CommunityErrorCode;
+import com.kkinikong.be.community.repository.CommunityPostLikeRepository;
+import com.kkinikong.be.community.repository.communityPost.CommunityPostRepository;
+import com.kkinikong.be.notification.event.payload.CommunityLikeEvent;
+import com.kkinikong.be.user.domain.User;
+import com.kkinikong.be.user.exception.UserException;
+import com.kkinikong.be.user.exception.errorcode.UserErrorCode;
+import com.kkinikong.be.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityLikeToggleExecutor {
+  private final CommunityPostRepository communityPostRepository;
+  private final CommunityPostLikeRepository communityPostLikeRepository;
+  private final UserRepository userRepository;
+  private final ApplicationEventPublisher eventPublisher;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public LikeToggleResponse togglePostLikeOnce(Long postId, Long userId) {
+
+    CommunityPost post =
+        communityPostRepository
+            .findById(postId)
+            .orElseThrow(() -> new CommunityException(CommunityErrorCode.COMMUNITY_POST_NOT_FOUND));
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+    Optional<CommunityPostLike> existing =
+        communityPostLikeRepository.findByCommunityPostIdAndUserId(postId, userId);
+
+    boolean isLiked;
+    if (existing.isPresent()) {
+      communityPostLikeRepository.delete(existing.get());
+      post.decrementLikeCount();
+      isLiked = false;
+    } else {
+      communityPostLikeRepository.save(
+          CommunityPostLike.builder().communityPost(post).user(user).build());
+      post.incrementLikeCount();
+      isLiked = true;
+      if (!post.getUser().getId().equals(userId)) {
+        eventPublisher.publishEvent(new CommunityLikeEvent(post.getUser(), user, post));
+      }
+    }
+    communityPostRepository.saveAndFlush(post); // 버전 충돌 감지
+    return LikeToggleResponse.from(isLiked, post.getLikeCount());
+  }
+}

--- a/src/main/java/com/kkinikong/be/community/service/CommunityLikeToggleExecutor.java
+++ b/src/main/java/com/kkinikong/be/community/service/CommunityLikeToggleExecutor.java
@@ -9,13 +9,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.kkinikong.be.community.domain.Comment;
+import com.kkinikong.be.community.domain.CommentLike;
 import com.kkinikong.be.community.domain.CommunityPost;
 import com.kkinikong.be.community.domain.CommunityPostLike;
 import com.kkinikong.be.community.dto.response.LikeToggleResponse;
 import com.kkinikong.be.community.exception.CommunityException;
 import com.kkinikong.be.community.exception.errorcode.CommunityErrorCode;
+import com.kkinikong.be.community.repository.CommentLikeRepository;
 import com.kkinikong.be.community.repository.CommunityPostLikeRepository;
+import com.kkinikong.be.community.repository.comment.CommentRepository;
 import com.kkinikong.be.community.repository.communityPost.CommunityPostRepository;
+import com.kkinikong.be.notification.event.payload.CommentLikeEvent;
 import com.kkinikong.be.notification.event.payload.CommunityLikeEvent;
 import com.kkinikong.be.user.domain.User;
 import com.kkinikong.be.user.exception.UserException;
@@ -28,6 +33,9 @@ public class CommunityLikeToggleExecutor {
   private final CommunityPostRepository communityPostRepository;
   private final CommunityPostLikeRepository communityPostLikeRepository;
   private final UserRepository userRepository;
+  private final CommentRepository commentRepository;
+  private final CommentLikeRepository commentLikeRepository;
+
   private final ApplicationEventPublisher eventPublisher;
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -37,10 +45,7 @@ public class CommunityLikeToggleExecutor {
         communityPostRepository
             .findById(postId)
             .orElseThrow(() -> new CommunityException(CommunityErrorCode.COMMUNITY_POST_NOT_FOUND));
-    User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    User user = getUserOrThrow(userId);
 
     Optional<CommunityPostLike> existing =
         communityPostLikeRepository.findByCommunityPostIdAndUserId(postId, userId);
@@ -61,5 +66,40 @@ public class CommunityLikeToggleExecutor {
     }
     communityPostRepository.saveAndFlush(post); // 버전 충돌 감지
     return LikeToggleResponse.from(isLiked, post.getLikeCount());
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public LikeToggleResponse toggleCommentLikeOnce(Long commentId, Long userId) {
+    Comment comment =
+        commentRepository
+            .findById(commentId)
+            .orElseThrow(() -> new CommunityException(CommunityErrorCode.COMMENT_NOT_FOUND));
+
+    User user = getUserOrThrow(userId);
+
+    Optional<CommentLike> commentLike =
+        commentLikeRepository.findByCommentIdAndUserId(commentId, userId);
+
+    boolean isLiked;
+    if (commentLike.isPresent()) {
+      commentLikeRepository.delete(commentLike.get());
+      comment.decrementLikeCount();
+      isLiked = false;
+    } else {
+      commentLikeRepository.save(CommentLike.builder().comment(comment).user(user).build());
+      comment.incrementLikeCount();
+      isLiked = true;
+      if (!comment.getUser().getId().equals(userId)) {
+        eventPublisher.publishEvent(new CommentLikeEvent(comment.getUser(), user, comment));
+      }
+    }
+    commentRepository.saveAndFlush(comment);
+    return LikeToggleResponse.from(isLiked, comment.getLikeCount());
+  }
+
+  private User getUserOrThrow(Long userId) {
+    return userRepository
+        .findById(userId)
+        .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
   }
 }

--- a/src/main/java/com/kkinikong/be/community/service/CommunityService.java
+++ b/src/main/java/com/kkinikong/be/community/service/CommunityService.java
@@ -23,7 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import com.kkinikong.be.cache.service.RedisTempleCacheService;
+import com.kkinikong.be.cache.service.RedisTemplateCacheService;
 import com.kkinikong.be.cache.type.RedisKey;
 import com.kkinikong.be.community.domain.Comment;
 import com.kkinikong.be.community.domain.CommentLike;
@@ -78,7 +78,7 @@ public class CommunityService {
 
   private final ApplicationEventPublisher eventPublisher;
   private final ImageService imageService;
-  private final RedisTempleCacheService redisTempleCacheService;
+  private final RedisTemplateCacheService redisTemplateCacheService;
   private final OpenSearchService openSearchService;
 
   final int maxRetries = 3;
@@ -290,7 +290,7 @@ public class CommunityService {
   public CommunityPostInfoResponse getCommunityPost(Long postId, Long userId) {
     CommunityPost communityPost = getCommunityPostOrThrow(postId);
 
-    redisTempleCacheService.increaseViewCounts(postId, RedisKey.COMMUNITY_POST_VIEWS_KEY);
+    redisTemplateCacheService.increaseViewCounts(postId, RedisKey.COMMUNITY_POST_VIEWS_KEY);
 
     List<Comment> allComments = commentRepository.findAllByCommunityPostId(postId);
     List<String> allImages =
@@ -314,7 +314,7 @@ public class CommunityService {
     keyword = keyword.trim();
     // 최근 검색어 추가 로직
     if (userId != null) {
-      redisTempleCacheService.saveRecentSearch(userId, keyword);
+      redisTemplateCacheService.saveRecentSearch(userId, keyword);
     }
 
     // Elasticsearch에서 검색어로 커뮤니티 게시글 페이징해서 가져옴
@@ -345,7 +345,7 @@ public class CommunityService {
   }
 
   public List<StoreRecentSearchKeyword> getRecentSearchKeywords(Long userId) {
-    List<String> recentSearches = redisTempleCacheService.getRecentSearches(userId);
+    List<String> recentSearches = redisTemplateCacheService.getRecentSearches(userId);
 
     if (recentSearches.isEmpty()) {
       return List.of();
@@ -355,7 +355,7 @@ public class CommunityService {
 
   public void deleteRecentSearchKeyword(Long userId, String keyword) {
     keyword = keyword.trim();
-    redisTempleCacheService.deleteRecentSearches(userId, keyword);
+    redisTemplateCacheService.deleteRecentSearches(userId, keyword);
   }
 
   @Transactional

--- a/src/main/java/com/kkinikong/be/community/service/CommunityService.java
+++ b/src/main/java/com/kkinikong/be/community/service/CommunityService.java
@@ -243,32 +243,48 @@ public class CommunityService {
 
   @Transactional
   public LikeToggleResponse postCommunityCommentLike(Long commentId, Long userId) {
-    Comment comment =
-        commentRepository
-            .findByIdForUpdate(commentId)
-            .orElseThrow(() -> new CommunityException(CommunityErrorCode.COMMENT_NOT_FOUND));
-    User user = getUserOrThrow(userId);
+    for (int attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        Comment comment =
+            commentRepository
+                .findById(commentId)
+                .orElseThrow(() -> new CommunityException(CommunityErrorCode.COMMENT_NOT_FOUND));
+        User user = getUserOrThrow(userId);
 
-    Optional<CommentLike> commentLike =
-        commentLikeRepository.findByCommentIdAndUserId(commentId, userId);
+        Optional<CommentLike> commentLike =
+            commentLikeRepository.findByCommentIdAndUserId(commentId, userId);
 
-    boolean isLiked;
-    if (commentLike.isPresent()) {
-      commentLikeRepository.delete(commentLike.get());
-      comment.decrementLikeCount();
-      isLiked = false;
-    } else {
-      commentLikeRepository.save(CommentLike.builder().comment(comment).user(user).build());
-      comment.incrementLikeCount();
-      isLiked = true;
+        boolean isLiked;
+        if (commentLike.isPresent()) {
+          commentLikeRepository.delete(commentLike.get());
+          comment.decrementLikeCount();
+          isLiked = false;
+        } else {
+          commentLikeRepository.save(CommentLike.builder().comment(comment).user(user).build());
+          comment.incrementLikeCount();
+          isLiked = true;
 
-      User receiver = comment.getUser();
-      // 알림 이벤트 발행
-      if (!comment.getUser().getId().equals(userId)) {
-        eventPublisher.publishEvent(new CommentLikeEvent(receiver, user, comment));
+          User receiver = comment.getUser();
+          // 알림 이벤트 발행
+          if (!comment.getUser().getId().equals(userId)) {
+            eventPublisher.publishEvent(new CommentLikeEvent(receiver, user, comment));
+          }
+        }
+
+        // 버전 충돌 조기 감지를 위해 flush
+        commentRepository.saveAndFlush(comment);
+        return LikeToggleResponse.from(isLiked, comment.getLikeCount());
+      } catch (ObjectOptimisticLockingFailureException e) {
+        if (attempt == maxRetries - 1) {
+          throw e;
+        }
+        try {
+          Thread.sleep(30L * attempt);
+        } catch (InterruptedException ignored) {
+        }
       }
     }
-    return LikeToggleResponse.from(isLiked, comment.getLikeCount());
+    throw new CommunityException(CommunityErrorCode.COMMENT_NOT_FOUND);
   }
 
   public CommunityPostInfoResponse getCommunityPost(Long postId, Long userId) {

--- a/src/main/java/com/kkinikong/be/community/service/CommunityService.java
+++ b/src/main/java/com/kkinikong/be/community/service/CommunityService.java
@@ -29,7 +29,6 @@ import com.kkinikong.be.community.domain.Comment;
 import com.kkinikong.be.community.domain.CommentLike;
 import com.kkinikong.be.community.domain.CommunityPost;
 import com.kkinikong.be.community.domain.CommunityPostImage;
-import com.kkinikong.be.community.domain.CommunityPostLike;
 import com.kkinikong.be.community.domain.document.CommunityPostDocument;
 import com.kkinikong.be.community.domain.type.Category;
 import com.kkinikong.be.community.dto.request.CommunityCommentRequest;
@@ -48,12 +47,10 @@ import com.kkinikong.be.community.exception.CommunityException;
 import com.kkinikong.be.community.exception.errorcode.CommunityErrorCode;
 import com.kkinikong.be.community.repository.CommentLikeRepository;
 import com.kkinikong.be.community.repository.CommunityPostImageRepository;
-import com.kkinikong.be.community.repository.CommunityPostLikeRepository;
 import com.kkinikong.be.community.repository.comment.CommentRepository;
 import com.kkinikong.be.community.repository.communityPost.CommunityPostRepository;
 import com.kkinikong.be.notification.event.payload.CommentLikeEvent;
 import com.kkinikong.be.notification.event.payload.CommentReplyEvent;
-import com.kkinikong.be.notification.event.payload.CommunityLikeEvent;
 import com.kkinikong.be.opensearch.service.OpenSearchService;
 import com.kkinikong.be.store.dto.response.StoreRecentSearchKeyword;
 import com.kkinikong.be.user.domain.User;
@@ -73,15 +70,15 @@ public class CommunityService {
   private final UserRepository userRepository;
   private final CommunityPostImageRepository communityPostImageRepository;
   private final CommentRepository commentRepository;
-  private final CommunityPostLikeRepository communityPostLikeRepository;
   private final CommentLikeRepository commentLikeRepository;
 
   private final ApplicationEventPublisher eventPublisher;
   private final ImageService imageService;
   private final RedisTemplateCacheService redisTemplateCacheService;
   private final OpenSearchService openSearchService;
+  private final CommunityLikeToggleExecutor communityLikeToggleExecutor;
 
-  final int maxRetries = 3;
+  final int MAX_RETRIES = 3;
 
   @Transactional
   public CommunityPostResponse postCommunityPost(CommunityPostRequest request, Long userId) {
@@ -192,49 +189,16 @@ public class CommunityService {
     return communityPosts.map(CommunityPostListResponse::from);
   }
 
-  @Transactional
   public LikeToggleResponse postCommunityPostLike(Long postId, Long userId) {
-    for (int attempt = 0; attempt < maxRetries; attempt++) {
+    for (int attempt = 0; attempt < MAX_RETRIES; attempt++) {
       try {
-        CommunityPost communityPost =
-            communityPostRepository
-                .findById(postId)
-                .orElseThrow(
-                    () -> new CommunityException(CommunityErrorCode.COMMUNITY_POST_NOT_FOUND));
-
-        User user = getUserOrThrow(userId);
-
-        Optional<CommunityPostLike> postLike =
-            communityPostLikeRepository.findByCommunityPostIdAndUserId(postId, userId);
-
-        boolean isLiked;
-        if (postLike.isPresent()) {
-          communityPostLikeRepository.delete(postLike.get());
-          communityPost.decrementLikeCount();
-          isLiked = false;
-        } else {
-          communityPostLikeRepository.save(
-              CommunityPostLike.builder().communityPost(communityPost).user(user).build());
-          communityPost.incrementLikeCount();
-          isLiked = true;
-
-          User receiver = communityPost.getUser();
-          // 알림 이벤트 발행
-          if (!communityPost.getUser().getId().equals(userId)) {
-            eventPublisher.publishEvent(new CommunityLikeEvent(receiver, user, communityPost));
-          }
-        }
-
-        // 버전 충돌 조기 감지를 위해 flush
-        communityPostRepository.saveAndFlush(communityPost);
-        return LikeToggleResponse.from(isLiked, communityPost.getLikeCount());
+        return communityLikeToggleExecutor.togglePostLikeOnce(postId, userId);
       } catch (ObjectOptimisticLockingFailureException e) {
-        if (attempt == maxRetries - 1) {
-          throw e;
-        }
+        if (attempt == MAX_RETRIES - 1) throw e;
         try {
-          Thread.sleep(30L * attempt);
-        } catch (InterruptedException ignored) {
+          Thread.sleep(30L * (attempt + 1));
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
         }
       }
     }
@@ -243,7 +207,7 @@ public class CommunityService {
 
   @Transactional
   public LikeToggleResponse postCommunityCommentLike(Long commentId, Long userId) {
-    for (int attempt = 0; attempt < maxRetries; attempt++) {
+    for (int attempt = 0; attempt < MAX_RETRIES; attempt++) {
       try {
         Comment comment =
             commentRepository
@@ -275,7 +239,7 @@ public class CommunityService {
         commentRepository.saveAndFlush(comment);
         return LikeToggleResponse.from(isLiked, comment.getLikeCount());
       } catch (ObjectOptimisticLockingFailureException e) {
-        if (attempt == maxRetries - 1) {
+        if (attempt == MAX_RETRIES - 1) {
           throw e;
         }
         try {

--- a/src/main/java/com/kkinikong/be/community/service/CommunityService.java
+++ b/src/main/java/com/kkinikong/be/community/service/CommunityService.java
@@ -26,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 import com.kkinikong.be.cache.service.RedisTemplateCacheService;
 import com.kkinikong.be.cache.type.RedisKey;
 import com.kkinikong.be.community.domain.Comment;
-import com.kkinikong.be.community.domain.CommentLike;
 import com.kkinikong.be.community.domain.CommunityPost;
 import com.kkinikong.be.community.domain.CommunityPostImage;
 import com.kkinikong.be.community.domain.document.CommunityPostDocument;
@@ -49,7 +48,6 @@ import com.kkinikong.be.community.repository.CommentLikeRepository;
 import com.kkinikong.be.community.repository.CommunityPostImageRepository;
 import com.kkinikong.be.community.repository.comment.CommentRepository;
 import com.kkinikong.be.community.repository.communityPost.CommunityPostRepository;
-import com.kkinikong.be.notification.event.payload.CommentLikeEvent;
 import com.kkinikong.be.notification.event.payload.CommentReplyEvent;
 import com.kkinikong.be.opensearch.service.OpenSearchService;
 import com.kkinikong.be.store.dto.response.StoreRecentSearchKeyword;
@@ -205,46 +203,16 @@ public class CommunityService {
     throw new CommunityException(CommunityErrorCode.COMMUNITY_POST_NOT_FOUND);
   }
 
-  @Transactional
   public LikeToggleResponse postCommunityCommentLike(Long commentId, Long userId) {
     for (int attempt = 0; attempt < MAX_RETRIES; attempt++) {
       try {
-        Comment comment =
-            commentRepository
-                .findById(commentId)
-                .orElseThrow(() -> new CommunityException(CommunityErrorCode.COMMENT_NOT_FOUND));
-        User user = getUserOrThrow(userId);
-
-        Optional<CommentLike> commentLike =
-            commentLikeRepository.findByCommentIdAndUserId(commentId, userId);
-
-        boolean isLiked;
-        if (commentLike.isPresent()) {
-          commentLikeRepository.delete(commentLike.get());
-          comment.decrementLikeCount();
-          isLiked = false;
-        } else {
-          commentLikeRepository.save(CommentLike.builder().comment(comment).user(user).build());
-          comment.incrementLikeCount();
-          isLiked = true;
-
-          User receiver = comment.getUser();
-          // 알림 이벤트 발행
-          if (!comment.getUser().getId().equals(userId)) {
-            eventPublisher.publishEvent(new CommentLikeEvent(receiver, user, comment));
-          }
-        }
-
-        // 버전 충돌 조기 감지를 위해 flush
-        commentRepository.saveAndFlush(comment);
-        return LikeToggleResponse.from(isLiked, comment.getLikeCount());
+        return communityLikeToggleExecutor.toggleCommentLikeOnce(commentId, userId);
       } catch (ObjectOptimisticLockingFailureException e) {
-        if (attempt == MAX_RETRIES - 1) {
-          throw e;
-        }
+        if (attempt == MAX_RETRIES - 1) throw e;
         try {
-          Thread.sleep(30L * attempt);
-        } catch (InterruptedException ignored) {
+          Thread.sleep(30L * (attempt + 1));
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
         }
       }
     }

--- a/src/main/java/com/kkinikong/be/community/service/CommunityService.java
+++ b/src/main/java/com/kkinikong/be/community/service/CommunityService.java
@@ -194,13 +194,17 @@ public class CommunityService {
       } catch (ObjectOptimisticLockingFailureException e) {
         if (attempt == MAX_RETRIES - 1) throw e;
         try {
+          log.warn(
+              "Optimistic locking failure on comment like toggle, retrying... Attempt: {} of {}",
+              attempt + 1,
+              MAX_RETRIES);
           Thread.sleep(30L * (attempt + 1));
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
         }
       }
     }
-    throw new CommunityException(CommunityErrorCode.COMMUNITY_POST_NOT_FOUND);
+    throw new CommunityException(CommunityErrorCode.RETRY_LIMIT_EXCEEDED);
   }
 
   public LikeToggleResponse postCommunityCommentLike(Long commentId, Long userId) {
@@ -210,13 +214,17 @@ public class CommunityService {
       } catch (ObjectOptimisticLockingFailureException e) {
         if (attempt == MAX_RETRIES - 1) throw e;
         try {
+          log.warn(
+              "Optimistic locking failure on comment like toggle, retrying... Attempt: {} of {}",
+              attempt + 1,
+              MAX_RETRIES);
           Thread.sleep(30L * (attempt + 1));
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
         }
       }
     }
-    throw new CommunityException(CommunityErrorCode.COMMENT_NOT_FOUND);
+    throw new CommunityException(CommunityErrorCode.RETRY_LIMIT_EXCEEDED);
   }
 
   public CommunityPostInfoResponse getCommunityPost(Long postId, Long userId) {

--- a/src/main/java/com/kkinikong/be/community/service/CommunityService.java
+++ b/src/main/java/com/kkinikong/be/community/service/CommunityService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -79,6 +80,8 @@ public class CommunityService {
   private final ImageService imageService;
   private final RedisTempleCacheService redisTempleCacheService;
   private final OpenSearchService openSearchService;
+
+  final int maxRetries = 3;
 
   @Transactional
   public CommunityPostResponse postCommunityPost(CommunityPostRequest request, Long userId) {
@@ -191,34 +194,51 @@ public class CommunityService {
 
   @Transactional
   public LikeToggleResponse postCommunityPostLike(Long postId, Long userId) {
-    CommunityPost communityPost =
-        communityPostRepository
-            .findByIdForUpdate(postId)
-            .orElseThrow(() -> new CommunityException(CommunityErrorCode.COMMUNITY_POST_NOT_FOUND));
+    for (int attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        CommunityPost communityPost =
+            communityPostRepository
+                .findById(postId)
+                .orElseThrow(
+                    () -> new CommunityException(CommunityErrorCode.COMMUNITY_POST_NOT_FOUND));
 
-    User user = getUserOrThrow(userId);
+        User user = getUserOrThrow(userId);
 
-    Optional<CommunityPostLike> postLike =
-        communityPostLikeRepository.findByCommunityPostIdAndUserId(postId, userId);
+        Optional<CommunityPostLike> postLike =
+            communityPostLikeRepository.findByCommunityPostIdAndUserId(postId, userId);
 
-    boolean isLiked;
-    if (postLike.isPresent()) {
-      communityPostLikeRepository.delete(postLike.get());
-      communityPost.decrementLikeCount();
-      isLiked = false;
-    } else {
-      communityPostLikeRepository.save(
-          CommunityPostLike.builder().communityPost(communityPost).user(user).build());
-      communityPost.incrementLikeCount();
-      isLiked = true;
+        boolean isLiked;
+        if (postLike.isPresent()) {
+          communityPostLikeRepository.delete(postLike.get());
+          communityPost.decrementLikeCount();
+          isLiked = false;
+        } else {
+          communityPostLikeRepository.save(
+              CommunityPostLike.builder().communityPost(communityPost).user(user).build());
+          communityPost.incrementLikeCount();
+          isLiked = true;
 
-      User receiver = communityPost.getUser();
-      // 알림 이벤트 발행
-      if (!communityPost.getUser().getId().equals(userId)) {
-        eventPublisher.publishEvent(new CommunityLikeEvent(receiver, user, communityPost));
+          User receiver = communityPost.getUser();
+          // 알림 이벤트 발행
+          if (!communityPost.getUser().getId().equals(userId)) {
+            eventPublisher.publishEvent(new CommunityLikeEvent(receiver, user, communityPost));
+          }
+        }
+
+        // 버전 충돌 조기 감지를 위해 flush
+        communityPostRepository.saveAndFlush(communityPost);
+        return LikeToggleResponse.from(isLiked, communityPost.getLikeCount());
+      } catch (ObjectOptimisticLockingFailureException e) {
+        if (attempt == maxRetries - 1) {
+          throw e;
+        }
+        try {
+          Thread.sleep(30L * attempt);
+        } catch (InterruptedException ignored) {
+        }
       }
     }
-    return LikeToggleResponse.from(isLiked, communityPost.getLikeCount());
+    throw new CommunityException(CommunityErrorCode.COMMUNITY_POST_NOT_FOUND);
   }
 
   @Transactional

--- a/src/main/java/com/kkinikong/be/convenience/dto/response/ConveniencePostListResponse.java
+++ b/src/main/java/com/kkinikong/be/convenience/dto/response/ConveniencePostListResponse.java
@@ -1,10 +1,15 @@
 package com.kkinikong.be.convenience.dto.response;
 
 import com.kkinikong.be.convenience.domain.ConveniencePost;
+import com.kkinikong.be.global.util.TimeUtil;
 
-public record ConveniencePostListResponse(Long id, String name, boolean isAvailable) {
+public record ConveniencePostListResponse(
+    Long id, String name, boolean isAvailable, String CreatedAt) {
   public static ConveniencePostListResponse from(ConveniencePost conveniencePost) {
     return new ConveniencePostListResponse(
-        conveniencePost.getId(), conveniencePost.getName(), conveniencePost.getIsAvailable());
+        conveniencePost.getId(),
+        conveniencePost.getName(),
+        conveniencePost.getIsAvailable(),
+        TimeUtil.relativeTimeFormatter(conveniencePost.getCreatedDate()));
   }
 }

--- a/src/main/java/com/kkinikong/be/convenience/dto/response/ConveniencePostListResponse.java
+++ b/src/main/java/com/kkinikong/be/convenience/dto/response/ConveniencePostListResponse.java
@@ -4,7 +4,7 @@ import com.kkinikong.be.convenience.domain.ConveniencePost;
 import com.kkinikong.be.global.util.TimeUtil;
 
 public record ConveniencePostListResponse(
-    Long id, String name, boolean isAvailable, String CreatedAt) {
+    Long id, String name, boolean isAvailable, String relativeCreatedAt) {
   public static ConveniencePostListResponse from(ConveniencePost conveniencePost) {
     return new ConveniencePostListResponse(
         conveniencePost.getId(),

--- a/src/main/java/com/kkinikong/be/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kkinikong/be/global/exception/handler/GlobalExceptionHandler.java
@@ -88,7 +88,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   @ExceptionHandler(ReviewException.class)
-  public ResponseEntity<Object> handleS3Exception(
+  public ResponseEntity<Object> handleReviewException(
       final ReviewException e, HttpServletRequest request) {
     logInfo(e.getErrorCode(), e, request);
     return handleExceptionInternal(e.getErrorCode());
@@ -102,7 +102,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   @ExceptionHandler(FeedbackException.class)
-  public ResponseEntity<Object> handleCommunityException(
+  public ResponseEntity<Object> handleFeedbackException(
       final FeedbackException e, HttpServletRequest request) {
     logInfo(e.getErrorCode(), e, request);
     return handleExceptionInternal(e.getErrorCode());

--- a/src/main/java/com/kkinikong/be/global/util/TimeUtil.java
+++ b/src/main/java/com/kkinikong/be/global/util/TimeUtil.java
@@ -1,4 +1,4 @@
-package com.kkinikong.be.community.util;
+package com.kkinikong.be.global.util;
 
 import java.time.Duration;
 import java.time.LocalDateTime;

--- a/src/main/java/com/kkinikong/be/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/kkinikong/be/notification/dto/response/NotificationResponse.java
@@ -1,6 +1,6 @@
 package com.kkinikong.be.notification.dto.response;
 
-import com.kkinikong.be.community.util.TimeUtil;
+import com.kkinikong.be.global.util.TimeUtil;
 import com.kkinikong.be.notification.domain.Notification;
 import com.kkinikong.be.notification.domain.type.NotificationType;
 

--- a/src/main/java/com/kkinikong/be/store/service/StoreService.java
+++ b/src/main/java/com/kkinikong/be/store/service/StoreService.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import com.kkinikong.be.cache.service.RedisTempleCacheService;
+import com.kkinikong.be.cache.service.RedisTemplateCacheService;
 import com.kkinikong.be.cache.type.RedisKey;
 import com.kkinikong.be.global.response.PageResponse;
 import com.kkinikong.be.review.domain.type.Tag;
@@ -43,7 +43,7 @@ public class StoreService {
   private final StoreRepository storeRepository;
   private final StoreKakaoApiClient storeKakaoApiClient;
   private final StoreGoogleApiClient storeGoogleApiClient;
-  private final RedisTempleCacheService redisTempleCacheService;
+  private final RedisTemplateCacheService redisTemplateCacheService;
   private final StoreScrapRepository storeScrapRepository;
   private final UserRepository userRepository;
   private final StoreTagCountRepository storeTagCountRepository;
@@ -106,7 +106,7 @@ public class StoreService {
   public StoreInfoResponse getStoreInfo(Long storeId, Long userId) {
     Store store = getStoreOrThrow(storeId);
 
-    redisTempleCacheService.increaseViewCounts(storeId, RedisKey.STORE_VIEWS_KEY);
+    redisTemplateCacheService.increaseViewCounts(storeId, RedisKey.STORE_VIEWS_KEY);
 
     String representativeTag =
         storeTagCountRepository

--- a/src/main/java/com/kkinikong/be/user/dto/response/MyCommentGroupByPostResponse.java
+++ b/src/main/java/com/kkinikong/be/user/dto/response/MyCommentGroupByPostResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import com.kkinikong.be.community.domain.Comment;
 import com.kkinikong.be.community.domain.CommunityPost;
-import com.kkinikong.be.community.util.TimeUtil;
+import com.kkinikong.be.global.util.TimeUtil;
 
 public record MyCommentGroupByPostResponse(
     Long postId,

--- a/src/main/java/com/kkinikong/be/user/dto/response/MypageReviewResponse.java
+++ b/src/main/java/com/kkinikong/be/user/dto/response/MypageReviewResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import jakarta.annotation.Nullable;
 
-import com.kkinikong.be.community.util.TimeUtil;
+import com.kkinikong.be.global.util.TimeUtil;
 import com.kkinikong.be.review.domain.Review;
 import com.kkinikong.be.review.domain.type.Tag;
 


### PR DESCRIPTION
## 📝 개요

[SCRUM-364] Refactor : 편의점 응답 및 기타 수정

## 🛠️ 작업 사항

- 편의점 리스트 응답에 상대시간 추가 (상대시간 유틸을 global로 이동)
- 커뮤니티 게시글, 댓글 좋아요를 비관적 > 낙관적 락으로 변경 (성능 향상을 위해!)
- api 프로필을 분리해서 기본 회원가입 배포환경에서는 불가능하도록 수정
- 기타 자잘한 이름들 수정

## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-364](https:///heroine.atlassian.net/browse/SCRUM-364)

## ✅ 체크리스트

- [x] 코드 리뷰 반영 완료
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] 문서 업데이트 필요 시 반영

## 🙏 기타 사항

추가적으로 리뷰어가 알아야 할 사항 작성


[SCRUM-364]: https://heroine.atlassian.net/browse/SCRUM-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 편의시설 게시글 목록에 상대 생성일 표시(예: “3시간 전”).
- Refactor
  - 커뮤니티 게시글/댓글 좋아요 토글에 낙관적 락 및 최대 3회 재시도 적용으로 동시성 상황에서 안정성과 정확성 향상.
  - 조회수 증가 및 최근 검색어 처리 로직 안정화.
- Chores
  - 기본 회원가입 API를 로컬 환경에서만 제공하도록 조정.
  - 시간 유틸리티 공용화에 따른 참조 경로 정리.
  - 캐시 서비스 명칭 정리에 따른 내부 참조 수정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->