### PR TITLE
[CHORE] Dockerfile에 JVM 옵션 적용 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:17
 WORKDIR /app
 COPY build/libs/kkinikong.jar app.jar
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jdk
 WORKDIR /app
 COPY build/libs/kkinikong.jar app.jar
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]


### PR DESCRIPTION
## 📝 개요

docker-compose.yml에서 `JAVA_OPTS`를 통해 JVM 메모리 및 GC 옵션을 설정하고 있었으나, 기존 Dockerfile에서는 java 실행 시 해당 환경 변수를 참조하지 않아 docker-compose.yml을 수정한 뒤에 `./deploy.sh`를 다시 실행해도 JVM 옵션이 실제 컨테이너 실행에 적용되지 않는 문제가 있었습니다. 
<br> 
아래 사진처럼 `JAVA_OPTS`에 설정들을 추가하는 작업을 진행 중이었습니다. 
<img width="400" height="280" alt="image" src="https://github.com/user-attachments/assets/eb41a33c-4cfc-4e49-8088-90cf84e2619e" />

<br> 

그래서 Dockerfile의 `ENTRYPOINT`를 수정하여, 컨테이너 실행 시점에 JAVA_OPTS가 JVM에 정상적으로 전달되도록 수정했습니다. 

## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-427](https:///heroine.atlassian.net/browse/SCRUM-427)

## ✅ 체크리스트

- [ ] 코드 리뷰 반영 완료
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] 문서 업데이트 필요 시 반영

## 🙏 기타 사항
이 작업은 내가 jvm gc를 튜닝하는 작업을 진행해보고 싶어서 !! 하다가 이 부분의 설정이 필요할 것 같아서 pr 올렸엉 !! 


[SCRUM-427]: https://heroine.atlassian.net/browse/SCRUM-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ