### PR TITLE
[REFACTOR] 지도 화면 가맹점 조회 로직 개선

### DIFF
--- a/src/main/java/com/kkinikong/be/cache/controller/CacheController.java
+++ b/src/main/java/com/kkinikong/be/cache/controller/CacheController.java
@@ -3,6 +3,7 @@ package com.kkinikong.be.cache.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import com.kkinikong.be.cache.service.CacheService;
+import com.kkinikong.be.cache.service.StoreCacheService;
 import com.kkinikong.be.global.response.ApiResponse;
 import com.kkinikong.be.user.utils.CustomUserDetails;
 
@@ -21,6 +23,7 @@ import com.kkinikong.be.user.utils.CustomUserDetails;
 public class CacheController {
 
   private final CacheService cacheService;
+  private final StoreCacheService storeCacheService;
 
   @Operation(summary = "가맹점 외부 링크 캐시 초기화", description = "카카오 api를 통해 받은 모든 가맹점 외부 링크 캐시를 삭제합니다")
   @DeleteMapping("/store-id")
@@ -34,5 +37,15 @@ public class CacheController {
   public ResponseEntity<ApiResponse<Object>> clearStoredOpeningHoursCache(
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     return ResponseEntity.ok(ApiResponse.from(cacheService.clearStoredOpeningHoursCache()));
+  }
+
+  @Operation(
+      summary = "가맹점 위치 데이터 강제 동기화",
+      description = "MySQL의 모든 가맹점 위치 정보를 Redis Geo Index로 적재합니다.")
+  @PostMapping("/store-locations")
+  public ResponseEntity<ApiResponse<Object>> syncStoreLocations(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    ;
+    return ResponseEntity.ok(ApiResponse.from(storeCacheService.syncStoreLocations()));
   }
 }

--- a/src/main/java/com/kkinikong/be/cache/service/RedisTemplateCacheService.java
+++ b/src/main/java/com/kkinikong/be/cache/service/RedisTemplateCacheService.java
@@ -4,7 +4,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.GeoResults;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.RedisGeoCommands;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.domain.geo.GeoReference;
+import org.springframework.data.redis.domain.geo.Metrics;
 import org.springframework.stereotype.Service;
 
 import lombok.extern.slf4j.Slf4j;
@@ -63,5 +69,36 @@ public class RedisTemplateCacheService {
   private static String generateRecentSearchKey(long userId) {
     String key = RedisKey.RECENT_SEARCHES_KEY.getKey() + ":" + userId;
     return key;
+  }
+
+  // 가맹점 위치 정보 단건 저장
+  public void saveStoreLocation(Long storeId, Double latitude, Double longitude) {
+    String key = RedisKey.STORE_LOCATIONS_KEY.getKey();
+    redisTemplate.opsForGeo().add(key, new Point(longitude, latitude), storeId.toString());
+  }
+
+  // 주변 가맹점 ID 리스트 조회
+  public List<Long> findNearbyStoreIds(Double latitude, Double longitude, Double radiusMeters) {
+    String key = RedisKey.STORE_LOCATIONS_KEY.getKey();
+
+    GeoResults<RedisGeoCommands.GeoLocation<Object>> results =
+        redisTemplate
+            .opsForGeo()
+            .search(
+                key,
+                GeoReference.fromCoordinate(longitude, latitude),
+                new Distance(radiusMeters, Metrics.METERS),
+                RedisGeoCommands.GeoSearchCommandArgs.newGeoSearchArgs().sortAscending());
+
+    if (results == null) return List.of();
+
+    return results.getContent().stream()
+        .map(res -> Long.parseLong(res.getContent().getName().toString()))
+        .toList();
+  }
+
+  // 가맹점 삭제 시 Geo 데이터도 삭제
+  public void removeStoreLocation(Long storeId) {
+    redisTemplate.opsForZSet().remove(RedisKey.STORE_LOCATIONS_KEY.getKey(), storeId.toString());
   }
 }

--- a/src/main/java/com/kkinikong/be/cache/service/RedisTemplateCacheService.java
+++ b/src/main/java/com/kkinikong/be/cache/service/RedisTemplateCacheService.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.GeoResults;
-import org.springframework.data.geo.Point;
 import org.springframework.data.redis.connection.RedisGeoCommands;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.domain.geo.GeoReference;
@@ -16,6 +15,7 @@ import org.springframework.stereotype.Service;
 import lombok.extern.slf4j.Slf4j;
 
 import com.kkinikong.be.cache.type.RedisKey;
+import com.kkinikong.be.store.domain.Store;
 
 @Service
 @Slf4j
@@ -71,12 +71,6 @@ public class RedisTemplateCacheService {
     return key;
   }
 
-  // 가맹점 위치 정보 단건 저장
-  public void saveStoreLocation(Long storeId, Double latitude, Double longitude) {
-    String key = RedisKey.STORE_LOCATIONS_KEY.getKey();
-    redisTemplate.opsForGeo().add(key, new Point(longitude, latitude), storeId.toString());
-  }
-
   // 주변 가맹점 ID 리스트 조회
   public List<Long> findNearbyStoreIds(Double latitude, Double longitude, Double radiusMeters) {
     String key = RedisKey.STORE_LOCATIONS_KEY.getKey();
@@ -97,8 +91,37 @@ public class RedisTemplateCacheService {
         .toList();
   }
 
-  // 가맹점 삭제 시 Geo 데이터도 삭제
-  public void removeStoreLocation(Long storeId) {
-    redisTemplate.opsForZSet().remove(RedisKey.STORE_LOCATIONS_KEY.getKey(), storeId.toString());
+  // 여러 ID를 한 번에 삭제
+  public void removeStoreLocationsBulk(List<Long> storeIds) {
+    if (storeIds == null || storeIds.isEmpty()) return;
+
+    String key = RedisKey.STORE_LOCATIONS_KEY.getKey();
+    Object[] members = storeIds.stream().map(Object::toString).toArray();
+
+    redisTemplate.opsForZSet().remove(key, members);
+  }
+
+  // 여러 데이터를 한 번에 저장
+  public void saveStoreLocationsBulk(List<Store> stores) {
+    String key = RedisKey.STORE_LOCATIONS_KEY.getKey();
+
+    redisTemplate.executePipelined(
+        (org.springframework.data.redis.core.RedisCallback<Object>)
+            connection -> {
+              for (Store store : stores) {
+                if (store.getId() != null) {
+                  connection
+                      .geoCommands()
+                      .geoAdd(
+                          key.getBytes(),
+                          new org.springframework.data.redis.connection.RedisGeoCommands
+                              .GeoLocation<>(
+                              store.getId().toString().getBytes(),
+                              new org.springframework.data.geo.Point(
+                                  store.getLongitude(), store.getLatitude())));
+                }
+              }
+              return null;
+            });
   }
 }

--- a/src/main/java/com/kkinikong/be/cache/service/ScheduledService.java
+++ b/src/main/java/com/kkinikong/be/cache/service/ScheduledService.java
@@ -20,6 +20,7 @@ public class ScheduledService {
 
   private final RedisTemplateCacheService redisTemplateCacheService;
   private final StoreRepository storeRepository;
+  private final StoreCacheService storeCacheService;
   private final CommunityPostRepository communityPostRepository;
 
   @Scheduled(cron = "0 0 * * * *") // 매시간 0분에 실행
@@ -58,5 +59,10 @@ public class ScheduledService {
         });
 
     redisTemplateCacheService.clearViewCounts(RedisKey.COMMUNITY_POST_VIEWS_KEY);
+  }
+
+  @Scheduled(cron = "0 0 3 * * *")
+  public void dailyLocationSync() {
+    storeCacheService.syncStoreLocations();
   }
 }

--- a/src/main/java/com/kkinikong/be/cache/service/StoreCacheService.java
+++ b/src/main/java/com/kkinikong/be/cache/service/StoreCacheService.java
@@ -1,0 +1,44 @@
+package com.kkinikong.be.cache.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.kkinikong.be.store.domain.Store;
+import com.kkinikong.be.store.repository.store.StoreRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StoreCacheService {
+
+  private final StoreRepository storeRepository;
+  private final RedisTemplateCacheService redisTemplateCacheService;
+
+  @Transactional(readOnly = true)
+  public String syncStoreLocations() {
+    log.info("가맹점 위치 정보 전수 동기화 시작...");
+
+    int pageSize = 1000;
+    int pageNumber = 0;
+    long totalCount = 0;
+
+    while (true) {
+      Page<Store> storePage = storeRepository.findAll(PageRequest.of(pageNumber, pageSize));
+
+      if (storePage.isEmpty()) break;
+
+      redisTemplateCacheService.saveStoreLocationsBulk(storePage.getContent());
+      totalCount += storePage.getNumberOfElements();
+      log.info("{}건 적재 완료...", totalCount);
+
+      if (!storePage.hasNext()) break;
+      pageNumber++;
+    }
+    return "성공적으로 " + totalCount + " 건의 위치 데이터를 동기화했습니다.";
+  }
+}

--- a/src/main/java/com/kkinikong/be/cache/type/RedisKey.java
+++ b/src/main/java/com/kkinikong/be/cache/type/RedisKey.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 public enum RedisKey {
   STORE_VIEWS_KEY("store-views"),
   COMMUNITY_POST_VIEWS_KEY("community-post-views"),
-  RECENT_SEARCHES_KEY("recent-searches");
+  RECENT_SEARCHES_KEY("recent-searches"),
+  STORE_LOCATIONS_KEY("store-locations"),
+  ;
 
   private final String key;
 

--- a/src/main/java/com/kkinikong/be/store/repository/store/StoreRepository.java
+++ b/src/main/java/com/kkinikong/be/store/repository/store/StoreRepository.java
@@ -18,6 +18,9 @@ public interface StoreRepository extends JpaRepository<Store, Long>, StoreReposi
 
   List<Store> findByRegion(String region);
 
+  @Query("SELECT s.id FROM Store s WHERE s.region = :region")
+  List<Long> findIdsByRegion(@Param("region") String region);
+
   @Modifying(clearAutomatically = true)
   @Query("UPDATE Store s SET s.viewCount = s.viewCount + :count WHERE s.id = :storeId")
   void incrementViews(@Param("storeId") Long storeId, @Param("count") Long count);

--- a/src/main/java/com/kkinikong/be/store/repository/store/StoreRepositoryCustom.java
+++ b/src/main/java/com/kkinikong/be/store/repository/store/StoreRepositoryCustom.java
@@ -22,4 +22,7 @@ public interface StoreRepositoryCustom {
       Long userId);
 
   List<Store> findTopViewedStores(Double latitude, Double longitude);
+
+  Page<Store> findStoresByIdsForMap(
+      List<Long> ids, String keyword, Category category, Pageable pageable, Long usedId);
 }

--- a/src/main/java/com/kkinikong/be/store/repository/store/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/kkinikong/be/store/repository/store/StoreRepositoryCustomImpl.java
@@ -84,7 +84,14 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
       whereBuilder.and(buildKeywordCondition(keyword));
     }
 
-    OrderSpecifier<?>[] sortOrder = new OrderSpecifier[] {store.id.asc()};
+    String format =
+        "FIELD({0}, " + String.join(", ", ids.stream().map(String::valueOf).toList()) + ")";
+    OrderSpecifier<?> fieldOrder =
+        new OrderSpecifier<>(
+            com.querydsl.core.types.Order.ASC,
+            Expressions.numberTemplate(Integer.class, format, store.id));
+    OrderSpecifier<?>[] sortOrder = new OrderSpecifier[] {fieldOrder, store.id.asc()};
+
     List<Tuple> tuples = fetchStores(whereBuilder, sortOrder, pageable, userId);
     List<Store> storeList = convertTuplesToStores(tuples, userId);
     long total = fetchTotalCount(whereBuilder);

--- a/src/main/java/com/kkinikong/be/store/repository/store/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/kkinikong/be/store/repository/store/StoreRepositoryCustomImpl.java
@@ -69,6 +69,29 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
     return queryFactory.selectFrom(store).where(whereBuilder).orderBy(orderBy).limit(8).fetch();
   }
 
+  @Override
+  public Page<Store> findStoresByIdsForMap(
+      List<Long> ids, String keyword, Category category, Pageable pageable, Long userId) {
+
+    BooleanBuilder whereBuilder = new BooleanBuilder();
+    whereBuilder.and(store.id.in(ids)); // redis에서 필터링해준 id 리스트 안에 포함된 데이터만 조회
+
+    if (category != null) {
+      whereBuilder.and(store.category.eq(category));
+    }
+
+    if (keyword != null && !keyword.isBlank()) {
+      whereBuilder.and(buildKeywordCondition(keyword));
+    }
+
+    OrderSpecifier<?>[] sortOrder = new OrderSpecifier[] {store.id.asc()};
+    List<Tuple> tuples = fetchStores(whereBuilder, sortOrder, pageable, userId);
+    List<Store> storeList = convertTuplesToStores(tuples, userId);
+    long total = fetchTotalCount(whereBuilder);
+
+    return new PageImpl<>(storeList, pageable, total);
+  }
+
   // 키워드 검색 조건 생성
   private BooleanBuilder buildKeywordCondition(String keyword) {
     String normalizedKeyword = keyword.replaceAll("\\s+", "");

--- a/src/main/java/com/kkinikong/be/store/service/StoreService.java
+++ b/src/main/java/com/kkinikong/be/store/service/StoreService.java
@@ -48,11 +48,12 @@ public class StoreService {
   private final UserRepository userRepository;
   private final StoreTagCountRepository storeTagCountRepository;
 
+  private static final double DEFAULT_RADIUS_METERS = 5000.0;
   private static final String NO_INFO = "NO_INFO";
   private static final double DEFAULT_LATITUDE = 37.545472;
   private static final double DEFAULT_LONGITUDE = 126.676902;
 
-  ///  카테고리와 정렬 조건 기반 가맹점 리스트 조회
+  //  카테고리와 정렬 조건 기반 가맹점 리스트 조회
   public PageResponse<StoreListItemResponse> getStoreList(
       Double latitude,
       Double longitude,
@@ -78,24 +79,29 @@ public class StoreService {
         storePage, store -> StoreListItemResponse.from(store, tagMap.get(store.getId())));
   }
 
-  /// 가맹점 지도 조회
+  // 가맹점 지도 조회
   public PageResponse<StoreMapListItemResponse> getStoreMapList(
       Double latitude,
       Double longitude,
-      Double radius,
+      Double radiusMeters,
       String keyword,
       Category category,
       int page,
       int size,
       Long userId) {
 
+    double radius = (radiusMeters != null) ? radiusMeters : DEFAULT_RADIUS_METERS;
+
     latitude = getOrDefault(latitude, StoreService.DEFAULT_LATITUDE);
     longitude = getOrDefault(longitude, StoreService.DEFAULT_LONGITUDE);
     Pageable pageable = PageRequest.of(page, size);
 
+    // redis에서 주변 가맹점 id만 가져오기
+    List<Long> nearbyIds =
+        redisTemplateCacheService.findNearbyStoreIds(latitude, longitude, radius);
+
     Page<Store> storePage =
-        storeRepository.findStoresUnified(
-            latitude, longitude, radius, keyword, category, StoreSort.DISTANCE, pageable, userId);
+        storeRepository.findStoresByIdsForMap(nearbyIds, keyword, category, pageable, userId);
     return PageResponse.from(storePage, StoreMapListItemResponse::from);
   }
 

--- a/src/main/java/com/kkinikong/be/store/service/StoreUploadService.java
+++ b/src/main/java/com/kkinikong/be/store/service/StoreUploadService.java
@@ -18,11 +18,13 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 
+import com.kkinikong.be.cache.service.RedisTemplateCacheService;
 import com.kkinikong.be.store.domain.Store;
 import com.kkinikong.be.store.domain.type.Category;
 import com.kkinikong.be.store.dto.response.StoreUploadResponse;
 import com.kkinikong.be.store.exception.StoreException;
 import com.kkinikong.be.store.exception.errorcode.StoreErrorCode;
+import com.kkinikong.be.store.repository.store.StoreRepository;
 import com.kkinikong.be.store.repository.storeupload.StoreJdbcRepository;
 
 @Slf4j
@@ -30,6 +32,8 @@ import com.kkinikong.be.store.repository.storeupload.StoreJdbcRepository;
 @RequiredArgsConstructor
 public class StoreUploadService {
   private final StoreJdbcRepository storeJdbcRepository;
+  private final StoreRepository storeRepository;
+  private final RedisTemplateCacheService redisTemplateCacheService;
 
   @Transactional
   public StoreUploadResponse upload(MultipartFile file) {
@@ -40,11 +44,23 @@ public class StoreUploadService {
     // 파일의 첫 번째 데이터에서 지역 정보 추출
     String targetRegion = newStores.get(0).getRegion();
 
+    // 삭제될 기존 데이터의 ID 확보
+    List<Long> oldStoreIds = storeRepository.findIdsByRegion(targetRegion);
+
     // 기존 데이터는 유지하며 정보 갱신, 신규 데이터는 추가
     storeJdbcRepository.upsertStores(newStores);
 
     // 새로운 파일에 없는 가맹점 삭제
     storeJdbcRepository.deleteMissingStores(targetRegion);
+
+    // redis에 해당 지역의 기존 데이터 삭제
+    redisTemplateCacheService.removeStoreLocationsBulk(oldStoreIds);
+
+    // 최신화된 해당 지역 데이터 조회
+    List<Store> updatedStores = storeRepository.findByRegion(targetRegion);
+
+    // redis에 최신 데이터 저장
+    redisTemplateCacheService.saveStoreLocationsBulk(updatedStores);
 
     return new StoreUploadResponse(newStores.size(), newStores.size());
   }


### PR DESCRIPTION
## 📝 개요
지도 화면에서의 '현위치 기반' 가맹점 조회 로직을 개선했습니다. 

## 🛠️ 작업 사항

### ⬅️ 기존 방식 
[저번 PR](https://github.com/Heroineeee/BE/pull/107) 에서 MySQL의 공간 함수 (`ST_Distance_Sphere`) 방식을 Boundingbox + 인덱스를 통해 개선을 하였습니다.

그럼에도 불구하고, 지도는 특성 상 드래그/확대/축소 시 api가 빈번하게 호출되기 때문에  더 개선할 수 있을 것 같다고 생각했습니다. 

### ➡️ 개선 사항 ->  Redis Geospatial 
- 지도 화면 가맹점 조회 로직 개선 
  - Redis에서 `GEORADIUS`를 이용해 반경 내 가맹점 id를 먼저 필터링한다. 
  - 추출된 id 리스트를 사용해 MySQL에서 상세 정보를 조회한다. 

- 데이터 적재 및 정합성 보장 
  - csv 파일 업로드 시 해당 지역 데이터를 redis에도 즉시 업데이트하도록 설정  
  - 매일 새벽 3시에 mysql-redis를 전수 동기화

- 관리자 전용 동기화 api 생성 
수동으로 전체 데이터를 동기화할 수 있는 관리자 전용 api


### 🚀 효과 
Redis는 위경도를 GeoHash라는 52비트 정수로 변환하여 이미 정렬된 상태로 보관합니다. 검색 시 특정 범위의 숫자들만 뽑아내기 때문에 연산 부하가 거의 없습니다. 기존 방식은 사용자가 지도를 움직일 때마다 db에서 연산을 수행해야 했습니다. Redis에는 아이디와 위경도만 저장하며 CPU 사용을 거의 하지 않습니다. 

그래서 기존 방식 대비 응답 속도가 약 5배정도 빨라졌습니다. 리스트는 여전히 Bounding Box + 인덱스 방식을, 지도는 redis geospatial을 사용하는데 지도 부분 API는 속도가 많이 개선된 것을 볼 수 있습니다. 리스트 부분은 그냥 두었는데, 지도만큼 api 호출이 되지 않는 것 같아서 !! 조금 더 고민해보고 개선할 수 있으면 할 수 있을 것 같아요 ! 
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/1f61fa4c-adf7-47de-a5ee-ca6de4cfef54" />


⚠️ 하나 걱정되는 점은 결국 Redis는 인메모리 저장소이기 때문에 메모리 부족이 우려되지만, 지금 db에 8만건 정도 있는데 지금 정도의 데이터는 견딜 수 있을 것같다고 판단됩니다. 메모리가 많이 부족하면,, 메모리를 늘리거나,,,사실 사용자 수가 엄청 많은 건 아니기 때문에 이전 PR 방식(Bounding box + 인덱스)으로 되돌아가는 것도 방법일 것 같아요~ 이 부분에 대해서 의견 줘도 좋을 것 같아용~

## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-428](https:///heroine.atlassian.net/browse/SCRUM-428)

## ✅ 테스트 

요 3가지가 다 잘 되는지 확인 부탁드립니당... !! 

1. 관리자 로그인 후에 연결된 db와 redis를 동기화 시키기 위해 `/api/v1/cache/store-locations`를 호출하여 db에 있는 데이터가 redis에 가맹점의 id, 위경도가 들어갔는지 확인 
2. `/api/v1/store/map` api 호출을 통해 호출이 잘 되는지 확인 
3. csv 파일을 새롭게 업로드 했을 때 redis가 동기화 되는지 확인 

## 🙏 기타 사항
나 db에 이번에 모니터링 회의에서 업데이트가 필요한 지역(인천, 부산)들은 다 db에 넣었엉 !! 대구 지역 쭉 한 번 해줫 !! 👍🏻 

## 📝 참고 문서 
https://wonyong-jang.github.io/bigdata/2021/05/12/BigData-Redis-Geospatial.html 

[SCRUM-428]: https://heroine.atlassian.net/browse/SCRUM-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ