### PR TITLE
[FEAT] 사용자 피드백 디스코드 알림/노션 데이터베이스 저장 기능 

### DIFF
--- a/src/main/java/com/kkinikong/be/feedback/event/FeedbackEventListener.java
+++ b/src/main/java/com/kkinikong/be/feedback/event/FeedbackEventListener.java
@@ -8,12 +8,17 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import lombok.RequiredArgsConstructor;
 
 import com.kkinikong.be.feedback.event.payload.FeedbackCreatedEvent;
+import com.kkinikong.be.feedback.util.discord.DiscordClient;
 
 @Component
 @RequiredArgsConstructor
 public class FeedbackEventListener {
 
+  private final DiscordClient discordClient;
+
   @Async("externalApiExecutor")
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-  public void handleFeedbackCreatedEvent(FeedbackCreatedEvent feedbackCreatedEvent) {}
+  public void handleFeedbackCreatedEvent(FeedbackCreatedEvent feedbackCreatedEvent) {
+    discordClient.sendFeedbackAlert(feedbackCreatedEvent);
+  }
 }

--- a/src/main/java/com/kkinikong/be/feedback/event/FeedbackEventListener.java
+++ b/src/main/java/com/kkinikong/be/feedback/event/FeedbackEventListener.java
@@ -9,16 +9,19 @@ import lombok.RequiredArgsConstructor;
 
 import com.kkinikong.be.feedback.event.payload.FeedbackCreatedEvent;
 import com.kkinikong.be.feedback.util.discord.DiscordClient;
+import com.kkinikong.be.feedback.util.notion.NotionClient;
 
 @Component
 @RequiredArgsConstructor
 public class FeedbackEventListener {
 
   private final DiscordClient discordClient;
+  private final NotionClient notionClient;
 
   @Async("externalApiExecutor")
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleFeedbackCreatedEvent(FeedbackCreatedEvent feedbackCreatedEvent) {
     discordClient.sendFeedbackAlert(feedbackCreatedEvent);
+    notionClient.sendFeedback(feedbackCreatedEvent);
   }
 }

--- a/src/main/java/com/kkinikong/be/feedback/event/FeedbackEventListener.java
+++ b/src/main/java/com/kkinikong/be/feedback/event/FeedbackEventListener.java
@@ -1,0 +1,19 @@
+package com.kkinikong.be.feedback.event;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+
+import com.kkinikong.be.feedback.event.payload.FeedbackCreatedEvent;
+
+@Component
+@RequiredArgsConstructor
+public class FeedbackEventListener {
+
+  @Async("externalApiExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleFeedbackCreatedEvent(FeedbackCreatedEvent feedbackCreatedEvent) {}
+}

--- a/src/main/java/com/kkinikong/be/feedback/event/payload/FeedbackCreatedEvent.java
+++ b/src/main/java/com/kkinikong/be/feedback/event/payload/FeedbackCreatedEvent.java
@@ -1,0 +1,10 @@
+package com.kkinikong.be.feedback.event.payload;
+
+import com.kkinikong.be.feedback.domain.Feedback;
+
+public record FeedbackCreatedEvent(int rating, String content, String type) {
+  public static FeedbackCreatedEvent from(Feedback feedback) {
+    return new FeedbackCreatedEvent(
+        feedback.getRating(), feedback.getContent(), feedback.getType());
+  }
+}

--- a/src/main/java/com/kkinikong/be/feedback/service/FeedbackService.java
+++ b/src/main/java/com/kkinikong/be/feedback/service/FeedbackService.java
@@ -10,14 +10,12 @@ import lombok.RequiredArgsConstructor;
 import com.kkinikong.be.feedback.domain.Feedback;
 import com.kkinikong.be.feedback.dto.request.FeedbackRequest;
 import com.kkinikong.be.feedback.repository.FeedbackRepository;
-import com.kkinikong.be.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
 public class FeedbackService {
 
   private final FeedbackRepository feedbackRepository;
-  private final UserRepository userRepository;
 
   @Transactional
   public void addFeedback(FeedbackRequest request) {

--- a/src/main/java/com/kkinikong/be/feedback/service/FeedbackService.java
+++ b/src/main/java/com/kkinikong/be/feedback/service/FeedbackService.java
@@ -2,6 +2,7 @@ package com.kkinikong.be.feedback.service;
 
 import java.util.stream.Collectors;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.kkinikong.be.feedback.domain.Feedback;
 import com.kkinikong.be.feedback.dto.request.FeedbackRequest;
+import com.kkinikong.be.feedback.event.payload.FeedbackCreatedEvent;
 import com.kkinikong.be.feedback.repository.FeedbackRepository;
 
 @Service
@@ -16,6 +18,7 @@ import com.kkinikong.be.feedback.repository.FeedbackRepository;
 public class FeedbackService {
 
   private final FeedbackRepository feedbackRepository;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public void addFeedback(FeedbackRequest request) {
@@ -25,5 +28,7 @@ public class FeedbackService {
         Feedback.builder().rating(request.rating()).content(request.content()).type(type).build();
 
     feedbackRepository.save(feedback);
+
+    eventPublisher.publishEvent(FeedbackCreatedEvent.from(feedback));
   }
 }

--- a/src/main/java/com/kkinikong/be/feedback/util/discord/DiscordClient.java
+++ b/src/main/java/com/kkinikong/be/feedback/util/discord/DiscordClient.java
@@ -1,0 +1,71 @@
+package com.kkinikong.be.feedback.util.discord;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.kkinikong.be.feedback.event.payload.FeedbackCreatedEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiscordClient {
+
+  private final WebClient webClient;
+
+  @Value("${external-api.discord.feedback-url}")
+  private String feedbackUrl;
+
+  public void sendFeedbackAlert(FeedbackCreatedEvent feedbackCreatedEvent) {
+    // 디스코드 규격에 맞는 JSON 바디 생성
+    Map<String, Object> body =
+        Map.of(
+            "embeds",
+            List.of(
+                Map.of(
+                    "title",
+                    "\uD83D\uDCCC 유저의 피드백 도착",
+                    "color",
+                    5814783,
+                    "fields",
+                    List.of(
+                        Map.of(
+                            "name",
+                            "⭐ 별점",
+                            "value",
+                            feedbackCreatedEvent.rating() + "점",
+                            "inline",
+                            false),
+                        Map.of(
+                            "name",
+                            "🏷️ 유형",
+                            "value",
+                            feedbackCreatedEvent.type(),
+                            "inline",
+                            false),
+                        Map.of(
+                            "name",
+                            "📝 내용",
+                            "value",
+                            feedbackCreatedEvent.content(),
+                            "inline",
+                            false)))));
+
+    // WebClient를 이용한 비동기 전송
+    webClient
+        .post()
+        .uri(feedbackUrl)
+        .bodyValue(body)
+        .retrieve()
+        .bodyToMono(String.class)
+        .doOnSuccess(response -> log.info("디스코드 알림 전송 성공"))
+        .doOnError(error -> log.error("디스코드 알림 전송 실패: {}", error.getMessage()))
+        .subscribe();
+  }
+}

--- a/src/main/java/com/kkinikong/be/feedback/util/notion/NotionClient.java
+++ b/src/main/java/com/kkinikong/be/feedback/util/notion/NotionClient.java
@@ -1,0 +1,62 @@
+package com.kkinikong.be.feedback.util.notion;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.kkinikong.be.feedback.event.payload.FeedbackCreatedEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotionClient {
+
+  private final WebClient webClient;
+
+  @Value("${external-api.notion.secret}")
+  private String secret;
+
+  @Value("${external-api.notion.database-id.feedback}")
+  private String feedbackId;
+
+  public void sendFeedback(FeedbackCreatedEvent feedbackCreatedEvent) {
+
+    // 현재 날짜
+    String today = LocalDate.now().toString();
+
+    Map<String, Object> body =
+        Map.of(
+            "parent", Map.of("database_id", feedbackId),
+            "properties",
+                Map.of(
+                    "내용",
+                        Map.of(
+                            "title",
+                            List.of(
+                                Map.of("text", Map.of("content", feedbackCreatedEvent.content())))),
+                    "별점", Map.of("number", feedbackCreatedEvent.rating()),
+                    "유형", Map.of("select", Map.of("name", feedbackCreatedEvent.type())),
+                    "피드백 날짜", Map.of("date", Map.of("start", today))));
+
+    webClient
+        .post()
+        .uri("https://api.notion.com/v1/pages")
+        .header("Authorization", "Bearer " + secret)
+        .header("Notion-Version", "2022-06-28")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(body)
+        .retrieve()
+        .bodyToMono(String.class)
+        .doOnSuccess(res -> log.info("노션 피드백 기록 성공"))
+        .doOnError(err -> log.error("노션 기록 실패: {}", err.getMessage()))
+        .subscribe();
+  }
+}

--- a/src/main/java/com/kkinikong/be/feedback/util/notion/NotionClient.java
+++ b/src/main/java/com/kkinikong/be/feedback/util/notion/NotionClient.java
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.kkinikong.be.feedback.domain.type.FeedbackType;
 import com.kkinikong.be.feedback.event.payload.FeedbackCreatedEvent;
 
 @Slf4j
@@ -32,6 +33,15 @@ public class NotionClient {
     // 현재 날짜
     String today = LocalDate.now().toString();
 
+    // 유형
+    List<Map<String, String>> typeList = new java.util.ArrayList<>();
+    if (feedbackCreatedEvent.type() != null && !feedbackCreatedEvent.type().isBlank()) {
+      for (String t : feedbackCreatedEvent.type().split(",")) {
+        String trimmed = t.trim();
+        typeList.add(Map.of("name", FeedbackType.valueOf(trimmed).getLabel()));
+      }
+    }
+
     Map<String, Object> body =
         Map.of(
             "parent", Map.of("database_id", feedbackId),
@@ -41,11 +51,16 @@ public class NotionClient {
                         Map.of(
                             "title",
                             List.of(
-                                Map.of("text", Map.of("content", feedbackCreatedEvent.content())))),
+                                Map.of(
+                                    "text",
+                                    Map.of(
+                                        "content",
+                                        feedbackCreatedEvent.content() != null
+                                            ? feedbackCreatedEvent.content()
+                                            : "")))),
                     "별점", Map.of("number", feedbackCreatedEvent.rating()),
-                    "유형", Map.of("select", Map.of("name", feedbackCreatedEvent.type())),
+                    "유형", Map.of("multi_select", typeList),
                     "피드백 날짜", Map.of("date", Map.of("start", today))));
-
     webClient
         .post()
         .uri("https://api.notion.com/v1/pages")

--- a/src/main/java/com/kkinikong/be/global/config/AsyncConfig.java
+++ b/src/main/java/com/kkinikong/be/global/config/AsyncConfig.java
@@ -22,4 +22,15 @@ public class AsyncConfig implements AsyncConfigurer {
     executor.initialize();
     return executor;
   }
+
+  @Bean(name = "externalApiExecutor")
+  public Executor externalApiExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(5);
+    executor.setMaxPoolSize(15);
+    executor.setQueueCapacity(50);
+    executor.setThreadNamePrefix("ExternalApiExecutor-");
+    executor.initialize();
+    return executor;
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,3 +51,7 @@ springdoc:
 external-api:
   discord:
     feedback-url: ${DISCORD_FEEDBACK_WEBHOOK_URL}
+  notion:
+    secret: ${NOTION_SECRET}
+    database-id:
+      feedback: ${NOTION_FEEDBACK_DATABASE_ID}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,7 @@ springdoc:
     tags_sorter: alpha
     operations_sorter: method # delete - get - patch - post - put 정렬
   use-fqn: true
+
+external-api:
+  discord:
+    feedback-url: ${DISCORD_FEEDBACK_WEBHOOK_URL}


### PR DESCRIPTION
## 📝 개요
사용자가 피드백을 작성한 경우, 디스코드 알림이 뜨고 노션 데이터베이스에 해당 내용이 저장하도록 구현했습니다. 기존에 우리(백엔드)만 db에서 피드백이나 신고를 확인할 수 있었는데, 디스코드 알림과 노션 데이터베이스에 저장하여 다른 팀원들도 쉽게 확인할 수 있도록 하기 위해서 진행했습니다. 

## 🛠️ 작업 사항

1. 디스코드 알림 
<img width="500" height="700" alt="image" src="https://github.com/user-attachments/assets/bd8b1aaa-a05c-434e-919e-feaf4d6faf05" />

2. 노션 데이터베이스 저장 
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/58b50f3b-151d-4a06-8ba6-0aa3644ee12c" />

## 🙏 전달 사항
테스트 해볼 때에는 디스코드 웹훅을 하나 만들고, 노션 api 설정해서 해보면 될 것 같아 ! 일단 내가 코드 만들고 내 개인 노션과 디스코드로 해봤을 때는 위에 사진처럼 잘 되는 거 확인했어 !! 

- 끼니콩 노션 API 관련해서는 선민님께 설정을 부탁해야해서, 노션에 좀 정리를 해봤어 !! 한 번 읽어봐도 좋아 !  [노션 링크](https://www.notion.so/API-2e20b19ad28b804a8567ce66c6eb6f8a?source=copy_link)  
- PR 확인하면, 선민님한테 부탁드릴겡 !! 
- 피드백도 머지되면, 신고 부분도 한 번 적용시켜보려고 합니당 ! 

## 🔗 관련 이슈 / JIRA

- JIRA 이슈: [SCRUM-433](https:///heroine.atlassian.net/browse/SCRUM-433)

## ✅ 체크리스트

- [ ] 코드 리뷰 반영 완료
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] 문서 업데이트 필요 시 반영



[SCRUM-433]: https://heroine.atlassian.net/browse/SCRUM-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ